### PR TITLE
Optimizer: hide fallback grid price slots in price chart

### DIFF
--- a/assets/js/components/Optimize/PriceChart.vue
+++ b/assets/js/components/Optimize/PriceChart.vue
@@ -66,6 +66,10 @@ export default defineComponent({
 			type: String,
 			default: "",
 		},
+		gridForecastMissing: {
+			type: Array as PropType<boolean[]>,
+			default: () => [],
+		},
 		currency: {
 			type: String as PropType<CURRENCY>,
 			required: true,
@@ -252,9 +256,13 @@ export default defineComponent({
 			const convertPrice = (price: number): number => price * 1000;
 
 			// Grid Import Price (solid line, price color)
+			// Slots without a real planner tariff are filled with a fallback rate on
+			// the backend; gap those points so the fallback value is not drawn.
 			datasets.push({
 				label: "Import",
-				data: this.evopt.req.time_series.p_N.map(convertPrice),
+				data: this.evopt.req.time_series.p_N.map((price, index) =>
+					this.gridForecastMissing[index] ? null : convertPrice(price)
+				),
 				borderColor: colors.grid,
 				backgroundColor: colors.grid,
 				fill: false,

--- a/assets/js/types/evcc.ts
+++ b/assets/js/types/evcc.ts
@@ -820,6 +820,7 @@ export interface BatteryDetail {
 export interface OptimizationDetails {
   timestamp: string[]; // Array of ISO timestamp strings
   batteryDetails: BatteryDetail[]; // Array of battery detail objects
+  gridForecastMissing?: boolean[]; // Per-slot flag: grid price filled with fallback rate
 }
 
 // Error response

--- a/assets/js/views/Optimize.vue
+++ b/assets/js/views/Optimize.vue
@@ -49,6 +49,7 @@
 						<PriceChart
 							:evopt="evopt"
 							:timestamp="evopt.details.timestamp[0]"
+							:grid-forecast-missing="evopt.details.gridForecastMissing"
 							:currency="currency"
 							:active-index="activeTooltipIndex"
 							@hover-index="setActiveTooltipIndex"

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -107,6 +107,9 @@ type batteryResult struct {
 type requestDetails struct {
 	Timestamps     []time.Time     `json:"timestamp"`
 	BatteryDetails []batteryDetail `json:"batteryDetails"`
+	// GridForecastMissing flags grid price slots filled with the fallback rate
+	// because the planner tariff had no value, so the UI can hide them.
+	GridForecastMissing []bool `json:"gridForecastMissing"`
 }
 
 const slotsPerHour = float64(time.Hour / tariff.SlotDuration)
@@ -174,7 +177,7 @@ func (site *Site) optimizerUpdate(battery []types.Measurement) error {
 		return fmt.Errorf("not enough forecast slots for meaningful optimization: %d < %d (planner=%d, feedIn=%d)", minLen, expectedSlots, len(planner), len(feedIn))
 	}
 
-	grid := fillMissingRateSlots(planner, minLen, plannerRateFallback)
+	grid, gridMissing := fillMissingRateSlots(planner, minLen, plannerRateFallback)
 
 	now := time.Now()
 	dt := timeSteps(minLen, now)
@@ -223,7 +226,8 @@ func (site *Site) optimizerUpdate(battery []types.Measurement) error {
 	pa := site.optimizerPA(req.TimeSeries.PN)
 
 	details := requestDetails{
-		Timestamps: asTimestamps(dt, now),
+		Timestamps:          asTimestamps(dt, now),
+		GridForecastMissing: gridMissing,
 	}
 
 	req.Grid = optimizer.GridConfig{
@@ -679,19 +683,24 @@ func currentRates(tariff api.Tariff) api.Rates {
 	})
 }
 
-func fillMissingRateSlots(rates api.Rates, maxLen int, fallback float64) api.Rates {
+// fillMissingRateSlots returns rates padded to maxLen slots. Slots without a
+// matching source rate are filled with fallback and flagged in the missing mask
+// so the UI can distinguish substituted values from real tariff data.
+func fillMissingRateSlots(rates api.Rates, maxLen int, fallback float64) (api.Rates, []bool) {
 	if maxLen <= 0 {
-		return nil
+		return nil, nil
 	}
 
 	start := time.Now().Truncate(tariff.SlotDuration)
 	res := make(api.Rates, 0, maxLen)
+	missing := make([]bool, 0, maxLen)
 
 	slotIndex := 0
 	for i := range maxLen {
 		slotStart := start.Add(time.Duration(i) * tariff.SlotDuration)
 		slotEnd := slotStart.Add(tariff.SlotDuration)
 		value := fallback
+		filled := true
 
 		for slotIndex < len(rates) && !rates[slotIndex].End.After(slotStart) {
 			slotIndex++
@@ -699,6 +708,7 @@ func fillMissingRateSlots(rates api.Rates, maxLen int, fallback float64) api.Rat
 
 		if slotIndex < len(rates) && !slotStart.Before(rates[slotIndex].Start) && slotStart.Before(rates[slotIndex].End) {
 			value = rates[slotIndex].Value
+			filled = false
 		}
 
 		res = append(res, api.Rate{
@@ -706,9 +716,10 @@ func fillMissingRateSlots(rates api.Rates, maxLen int, fallback float64) api.Rat
 			End:   slotEnd,
 			Value: value,
 		})
+		missing = append(missing, filled)
 	}
 
-	return res
+	return res, missing
 }
 
 func rateHorizonSlots(rates api.Rates) int {


### PR DESCRIPTION
## Problem

The optimizer fills planner tariff gaps with a fixed fallback rate (`plannerRateFallback = 20`) so the solver avoids charging in those slots. In the **Optimize → Input: Grid Prices** chart this fallback value dwarfs the real prices and draws a misleading spike on the Import line.

## Change

- `fillMissingRateSlots` now also returns a per-slot `missing` mask (true where the fallback was substituted).
- The mask is published on `evopt.details.gridForecastMissing`.
- `PriceChart.vue` maps those slots to `null`, so the stepped Import line simply **gaps** — no line is drawn where the price was substituted.

The value sent to the optimizer is unchanged; this is display-only. The Export line and everything else are untouched.

## Verification

- `go build ./core/`, `go vet`, and `go test ./core/` pass.
- Frontend `vue-tsc`, eslint, and prettier are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)