### PR TITLE
CI: auto-resolve fork-divergence conflicts in tag sync

### DIFF
--- a/.github/scripts/resolve_tag_sync.py
+++ b/.github/scripts/resolve_tag_sync.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Auto-resolve the recurring, mechanical conflicts produced by the daily tag
+sync (see .github/workflows/sync-tags.yml), which merges `master` (this fork)
+into each new upstream release tag.
+
+The fork permanently diverges from upstream in a few well-understood ways, and
+those divergences generate the same conflicts on almost every sync:
+
+  1. Deleted workflows  - the fork removes some upstream workflow files
+                          (Claude review, documentation). Kept deleted.
+  2. Removed jobs       - the fork only builds Docker, so it removes jobs such
+                          as `apt`, the Home Assistant add-on (`hassio`) and the
+                          fly.io `demo` job. Kept removed.
+  3. Runner type        - upstream uses `depot-*` runners; the fork uses the
+                          GitHub-hosted runners. Keep the fork's runner.
+
+Any *other* conflict (a real change to a job the fork keeps, a header/`on:`
+change, a brand-new upstream job that conflicts, etc.) is left unresolved so the
+sync workflow opens a pull request for manual review.
+
+Only files under .github/workflows/ are touched; conflicts anywhere else are
+always left for a pull request.
+
+The script operates on the in-progress merge's index stages:
+  :1 = merge base, :2 = ours (HEAD = upstream tag), :3 = theirs (master = fork).
+
+Exit code is always 0; the caller decides commit-vs-PR from the remaining
+unmerged paths.
+"""
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+WORKFLOW_PREFIX = ".github/workflows/"
+JOB_KEY = re.compile(r"^  ([A-Za-z0-9_.-]+):\s*(#.*)?$")
+RUNS_ON = re.compile(r"^\s*runs-on:")
+
+
+def git(*args, check=True):
+    return subprocess.run(
+        ["git", *args], capture_output=True, text=True, check=check
+    )
+
+
+def stage_blob(stage: int, path: str):
+    """Return the text of an index stage, or None if that stage is absent
+    (e.g. no merge base, or the file is deleted on one side)."""
+    r = git("show", f":{stage}:{path}", check=False)
+    return r.stdout if r.returncode == 0 else None
+
+
+def merge_file(ours: str, base: str, theirs: str, favor: str) -> str:
+    """Three-way merge favoring one side on conflicts, keeping cleanly-merged
+    content everywhere else. favor is 'ours' (upstream) or 'theirs' (fork)."""
+    fds = []
+    try:
+        paths = []
+        for content in (ours, base, theirs):
+            fd, p = tempfile.mkstemp(suffix=".yml")
+            os.write(fd, (content or "").encode())
+            os.close(fd)
+            paths.append(p)
+            fds.append(p)
+        # git merge-file <current> <base> <other>; current=ours, other=theirs
+        r = subprocess.run(
+            ["git", "merge-file", "-p", f"--{favor}", paths[0], paths[1], paths[2]],
+            capture_output=True,
+            text=True,
+        )
+        return r.stdout
+    finally:
+        for p in fds:
+            try:
+                os.unlink(p)
+            except OSError:
+                pass
+
+
+def parse_workflow(text: str):
+    """Split a workflow into (header_lines, {job_name: block_lines}).
+
+    header = everything up to and including the top-level `jobs:` line;
+    each job block spans from its 2-space-indented key to the next one."""
+    lines = (text or "").split("\n")
+    header = []
+    jobs = {}
+    order = []
+    i = 0
+    # header up to and including the `jobs:` line
+    while i < len(lines):
+        header.append(lines[i])
+        if lines[i].rstrip() == "jobs:":
+            i += 1
+            break
+        i += 1
+    cur = None
+    for line in lines[i:]:
+        m = JOB_KEY.match(line)
+        if m:
+            cur = m.group(1)
+            jobs[cur] = []
+            order.append(cur)
+        if cur is None:
+            # Only comments/blanks legitimately sit between `jobs:` and the first
+            # job. Ignore anything else: a conflict that straddles a commented-out
+            # job (e.g. the fork disables check_date while upstream edits it) can
+            # leave orphaned job-body lines here that must not skew the compare.
+            continue
+        jobs[cur].append(line)
+    return header, jobs, order
+
+
+def canon(lines):
+    """Canonical form for *comparison only*: ignore blank lines, full-line
+    comments and trailing whitespace. This lets a job the fork disabled by
+    commenting it out (e.g. check_date) compare equal to its absence, and
+    ignores pure formatting differences. The resolution text keeps comments."""
+    out = []
+    for ln in lines:
+        s = ln.rstrip()
+        if s == "" or s.lstrip().startswith("#"):
+            continue
+        out.append(s)
+    return out
+
+
+def strip_runs_on(lines):
+    return [ln for ln in lines if not RUNS_ON.match(ln)]
+
+
+def job_names(text):
+    return set(parse_workflow(text)[1].keys())
+
+
+def classify(base, ours, theirs):
+    """Decide whether a workflow content conflict is confined to the fork's
+    known divergences. Returns (benign, resolution_text)."""
+    fork = merge_file(ours, base, theirs, "theirs")  # fork wins conflicts
+    upstream = merge_file(ours, base, theirs, "ours")  # upstream wins conflicts
+
+    if canon(fork.split("\n")) == canon(upstream.split("\n")):
+        return True, fork  # conflict was cosmetic (whitespace/comments only)
+
+    fh, fj, _ = parse_workflow(fork)
+    uh, uj, _ = parse_workflow(upstream)
+
+    # header (name/on/permissions/...) must not differ -> otherwise real conflict
+    if canon(fh) != canon(uh):
+        return False, None
+
+    base_jobs = job_names(base) if base is not None else set()
+    theirs_jobs = job_names(theirs) if theirs is not None else set()
+    # jobs the fork deliberately removed: existed in base, gone from the fork
+    fork_removed = base_jobs - theirs_jobs
+
+    dropped = set(uj) - set(fj)  # jobs lost by choosing the fork's side
+    if not dropped.issubset(fork_removed):
+        return False, None  # dropping a job the fork didn't remove -> review
+
+    if set(fj) - set(uj):
+        return False, None  # unexpected fork-only job appeared on conflict
+
+    # shared jobs may differ ONLY by runner type
+    for name in set(fj) & set(uj):
+        if canon(strip_runs_on(fj[name])) != canon(strip_runs_on(uj[name])):
+            return False, None
+
+    return True, fork
+
+
+def main():
+    unmerged = git("diff", "--name-only", "--diff-filter=U").stdout.split()
+    for path in unmerged:
+        if not path.startswith(WORKFLOW_PREFIX):
+            print(f"leave (not a workflow): {path}")
+            continue
+
+        # modify/delete: file removed on master (theirs) -> honor the deletion
+        if git("cat-file", "-e", f"master:{path}", check=False).returncode != 0:
+            git("rm", "-q", "--", path)
+            print(f"resolved (kept deletion): {path}")
+            continue
+
+        base = stage_blob(1, path)
+        ours = stage_blob(2, path)
+        theirs = stage_blob(3, path)
+        if ours is None or theirs is None:
+            print(f"leave (add/delete conflict): {path}")
+            continue
+
+        benign, resolution = classify(base, ours, theirs)
+        if benign:
+            with open(path, "w") as f:
+                f.write(resolution)
+            git("add", "--", path)
+            print(f"resolved (fork divergence only): {path}")
+        else:
+            print(f"leave (needs review): {path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_resolve_tag_sync.py
+++ b/.github/scripts/test_resolve_tag_sync.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Unit tests for the tag-sync conflict classifier.
+
+Run: python3 .github/scripts/test_resolve_tag_sync.py
+No third-party dependencies (stdlib only), so it runs anywhere the sync does.
+
+Convention (matches sync-tags.yml `git merge master` into the upstream tag):
+  ours   = upstream release tag (HEAD)
+  theirs = this fork (master)
+"""
+
+import sys
+
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+import resolve_tag_sync as R  # noqa: E402
+
+PASS = 0
+FAIL = 0
+
+
+def check(name, got, want):
+    global PASS, FAIL
+    if got == want:
+        PASS += 1
+        print(f"ok   - {name}")
+    else:
+        FAIL += 1
+        print(f"FAIL - {name}: got {got!r}, want {want!r}")
+
+
+def wf(header, jobs):
+    """Build a workflow doc from a header and a list of (name, body-lines)."""
+    out = list(header) + ["jobs:"]
+    for name, body in jobs:
+        out.append(f"  {name}:")
+        out.extend("    " + b for b in body)
+    return "\n".join(out) + "\n"
+
+
+HEADER = ["name: W", "on:", "  push:"]
+
+
+def docker(runner="ubuntu-24.04", cleanup="fork"):
+    step = "run: fork-cleanup" if cleanup == "fork" else "run: upstream-cleanup"
+    return ("docker", [f"runs-on: {runner}", "steps:", f"- name: x", f"  {step}"])
+
+
+# 1. runner-type only: shared job differs solely in runs-on -> benign
+base = wf(HEADER, [docker(runner="depot-x")])
+ours = wf(HEADER, [docker(runner="depot-arm")])   # upstream changes runner
+theirs = wf(HEADER, [docker(runner="ubuntu-24.04")])  # fork changes runner
+benign, _ = R.classify(base, ours, theirs)
+check("runner-type only -> benign", benign, True)
+
+# 2. removed job: fork deleted apt, upstream modified it -> benign
+base = wf(HEADER, [docker(), ("apt", ["runs-on: depot-x", "run: old"])])
+ours = wf(HEADER, [docker(), ("apt", ["runs-on: depot-x", "run: new-upstream"])])
+theirs = wf(HEADER, [docker()])
+benign, _ = R.classify(base, ours, theirs)
+check("removed job (apt) -> benign", benign, True)
+
+# 3. genuine change in a kept job -> needs review (PR)
+base = wf(HEADER, [("docker", ["runs-on: ubuntu-24.04", "run: base"])])
+ours = wf(HEADER, [("docker", ["runs-on: ubuntu-24.04", "run: upstream-change"])])
+theirs = wf(HEADER, [("docker", ["runs-on: ubuntu-24.04", "run: fork-change"])])
+benign, _ = R.classify(base, ours, theirs)
+check("kept-job content conflict -> PR", benign, False)
+
+# 4. brand-new upstream job (absent from base) conflicts with fork content and
+#    would be dropped by the fork side -> PR. Both sides append a different job
+#    at the same spot, forcing an add/add conflict.
+base = wf(HEADER, [docker()])
+ours = wf(HEADER, [docker(), ("newjob", ["runs-on: depot-x", "run: n"])])
+theirs = wf(HEADER, [docker(), ("forkextra", ["runs-on: ubuntu-24.04", "run: f"])])
+benign, _ = R.classify(base, ours, theirs)
+check("new upstream job + conflict -> PR", benign, False)
+
+# 5. combined benign: removed job AND runner-type change together -> benign
+base = wf(HEADER, [docker(runner="depot-x"), ("hassio", ["runs-on: depot-x", "run: h"])])
+ours = wf(HEADER, [docker(runner="depot-arm"), ("hassio", ["runs-on: depot-x", "run: h2"])])
+theirs = wf(HEADER, [docker(runner="ubuntu-24.04")])
+benign, _ = R.classify(base, ours, theirs)
+check("removed job + runner change -> benign", benign, True)
+
+# 6. header (top-level) conflict -> PR
+base = wf(["name: W", "on:", "  push:"], [docker()])
+ours = wf(["name: W", "on:", "  push:", "  schedule: upstream"], [docker()])
+theirs = wf(["name: W", "on:", "  push:", "  schedule: fork"], [docker()])
+benign, _ = R.classify(base, ours, theirs)
+check("header conflict -> PR", benign, False)
+
+print(f"\n{PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)

--- a/.github/workflows/sync-tags.yml
+++ b/.github/workflows/sync-tags.yml
@@ -78,11 +78,29 @@ jobs:
 
                 # Attempt to merge the master branch into the new branch
                 git merge master --no-edit || {
-                  # If there's a merge conflict, create a pull request
-                  echo "Merge conflict detected for tag ${TAG}. Creating pull request."
-                  git push origin "tag-${TAG}"
-                  gh pr create --title "Resolve merge conflict for tag ${NEW_TAG}" --body "A merge conflict was detected while syncing tag ${NEW_TAG}. Please resolve the conflict in this PR." --head master --base "tag-${TAG}"
-                  continue
+                  echo "Merge conflict detected for tag ${TAG}. Attempting auto-resolution."
+
+                  # Auto-resolve conflicts that are confined to the fork's known,
+                  # permanent divergences from upstream in .github/workflows/:
+                  # deleted workflows, removed jobs (apt, Home Assistant add-on, ...)
+                  # and runner type. Any other conflict is left untouched so the
+                  # sync opens a pull request. See resolve_tag_sync.py for details.
+                  # The script is merged in cleanly from master, so it is present
+                  # in the working tree even though the upstream tag lacks it.
+                  python3 .github/scripts/resolve_tag_sync.py
+
+                  # If any conflicts remain, hand off to a manual pull request.
+                  if [ -n "$(git diff --name-only --diff-filter=U)" ]; then
+                    echo "Unresolved conflicts remain for tag ${TAG}. Creating pull request."
+                    git merge --abort
+                    git push origin "tag-${TAG}"
+                    gh pr create --title "Resolve merge conflict for tag ${NEW_TAG}" --body "A merge conflict was detected while syncing tag ${NEW_TAG}. Please resolve the conflict in this PR." --head master --base "tag-${TAG}"
+                    continue
+                  fi
+
+                  # All conflicts were fork divergences; finalize the auto-resolved merge.
+                  echo "All conflicts were fork divergences. Committing auto-resolved merge."
+                  git commit --no-edit
                 }
                 # Tag the branch with .0 appended to the original tag name
                 git tag "${NEW_TAG}"

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __debug_bin*
 *.db
 *.gz
 *.py
+!.github/scripts/*.py
+__pycache__/
 testdata/**/*
 *.log
 *.json


### PR DESCRIPTION
## Problem

The daily tag sync (`sync-tags.yml`) creates a `tag-X` branch from each new upstream release tag and runs `git merge master`. On **any** conflict it opens a manual *"Resolve merge conflict for tag X"* PR (e.g. #46). Almost every one of those comes from the fork's permanent, mechanical divergences in `.github/workflows/`:

- **Deleted workflows** — Claude review, documentation (modify/delete every time upstream touches them)
- **Removed jobs** — `apt`, the Home Assistant add-on (`hassio`), etc. (the fork only builds Docker)
- **Runner type** — upstream uses `depot-*` runners; the fork uses GitHub-hosted runners

## Change

After a failed merge, `sync-tags.yml` runs **`.github/scripts/resolve_tag_sync.py`**, which auto-resolves conflicts *confined to those divergences* and leaves everything else for a PR:

- Keeps the fork's side on conflicting hunks while **preserving upstream's cleanly-merged changes** (e.g. `actions/checkout` / `cache` version bumps in active jobs).
- Only touches `.github/workflows/`. Conflicts anywhere else always open a PR.
- A conflict is auto-resolved **only if** the difference is limited to: files the fork deleted, jobs the fork removed (detected generically — apt/hassio/demo/future), and `runs-on:` runner type. Anything else — a real change to a job the fork keeps (e.g. the Docker GHCR-cleanup step), a header/`on:` change, a brand-new upstream job — is left untouched → PR.

If, after auto-resolution, no conflicts remain, the merge is committed, tagged, and pushed automatically. If any remain, it aborts and opens the manual PR exactly as before.

## Tests

`.github/scripts/test_resolve_tag_sync.py` — stdlib only (no third-party deps, runs on any GitHub runner). Covers the decision boundaries: runner-type only, removed job, kept-job content conflict, new upstream job, combined benign, header conflict.

Also verified end-to-end against the **real #46** conflict:
- The 4 deleted workflows + `release.yml` auto-resolve (byte-identical to the hand-merge).
- `nightly.yml` correctly routes to a PR — it has a genuine conflict in the kept `docker` job (fork's GHCR tag-cleanup vs upstream's Docker Hub cleanup), which is *not* a whitelisted divergence.
- A synthetic fully-benign cycle (removed job + runner change) auto-commits.

## Notes

- Deletions are now scoped to `.github/workflows/` (a file deleted elsewhere still opens a PR), per the requested tightening.
- On a *mixed* cycle (some benign + some genuine conflicts) it still opens one PR for the whole merge, rather than partially committing. Safe and simple; can be revisited if partial auto-resolution is wanted.
- The classifier is Python (stdlib); `.gitignore` gains a scoped `!.github/scripts/*.py` exception since the repo otherwise ignores `*.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)