### PR TITLE
CI: create GitHub Release after Docker publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
   release:
     name: Create GitHub Release
     needs:
-      - call-build-workflow
+      - docker
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
## Problem

In `release.yml`, both `release` (Create GitHub Release) and `docker` (Publish Docker :release) depended only on `call-build-workflow`, so they ran **in parallel**. The GitHub Release could be created before the Docker image was published.

## Change

`release` now `needs: docker`, giving the order:

`call-build-workflow` → `docker` → `release`

So the Docker image is published first, then the GitHub Release is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)