### PR TITLE
UI: relocate battery optimizer settings after 0.311.0 redesign

### DIFF
--- a/assets/js/components/Battery/BatteryConfigCard.vue
+++ b/assets/js/components/Battery/BatteryConfigCard.vue
@@ -86,6 +86,60 @@
 					{{ $t("battery.config.discharge") }}
 				</label>
 			</div>
+
+			<div class="border-top pt-3 mt-3">
+				<div class="form-check form-switch mb-3">
+					<input
+						id="batteryExpSocGoalEnabled"
+						:checked="batteryOptimizerSocGoalEnabled"
+						class="form-check-input"
+						type="checkbox"
+						role="switch"
+						@change="changeBatteryOptimizerSocGoalEnabled"
+					/>
+					<label class="form-check-label" for="batteryExpSocGoalEnabled">
+						{{ $t("batterySettings.optimizerSocGoal.enable") }}
+					</label>
+				</div>
+				<div class="row g-3 align-items-end">
+					<div class="col-sm-6">
+						<label class="form-label" for="batteryExpSocGoalTime">
+							{{ $t("batterySettings.optimizerSocGoal.time") }}
+						</label>
+						<input
+							id="batteryExpSocGoalTime"
+							v-model="selectedBatteryOptimizerSocGoalTime"
+							type="time"
+							class="form-control mx-0"
+							:disabled="!batteryOptimizerSocGoalEnabled"
+							@change="changeBatteryOptimizerSocGoalTime"
+						/>
+					</div>
+					<div class="col-sm-6">
+						<label class="form-label" for="batteryExpSocGoal">
+							{{ $t("batterySettings.optimizerSocGoal.soc") }}
+						</label>
+						<select
+							id="batteryExpSocGoal"
+							v-model="selectedBatteryOptimizerSocGoal"
+							class="form-select"
+							:disabled="!batteryOptimizerSocGoalEnabled"
+							@change="changeBatteryOptimizerSocGoal"
+						>
+							<option
+								v-for="option in batteryOptimizerSocGoalOptions"
+								:key="option.value"
+								:value="option.value"
+							>
+								{{ option.name }}
+							</option>
+						</select>
+					</div>
+				</div>
+				<small class="d-block text-muted mt-2">
+					{{ $t("batterySettings.optimizerSocGoal.hint") }}
+				</small>
+			</div>
 		</template>
 	</Card>
 </template>
@@ -113,6 +167,8 @@ export default defineComponent({
 		prioritySoc: { type: Number, default: 0 },
 		bufferStartSoc: { type: Number, default: 0 },
 		batteryDischargeControl: Boolean,
+		batteryOptimizerSocGoal: { type: [Number, null] as PropType<number | null>, default: null },
+		batteryOptimizerSocGoalTime: { type: String, default: "21:00" },
 		battery: { type: Object as PropType<Battery> },
 	},
 	data() {
@@ -120,6 +176,8 @@ export default defineComponent({
 			selectedBufferSoc: 100,
 			selectedPrioritySoc: 0,
 			selectedBufferStartSoc: 0,
+			selectedBatteryOptimizerSocGoal: 20,
+			selectedBatteryOptimizerSocGoalTime: "21:00",
 		};
 	},
 	computed: {
@@ -157,6 +215,18 @@ export default defineComponent({
 		selectedBufferStartName(): string {
 			return this.getBufferStartName(this.selectedBufferStartSoc);
 		},
+		batteryOptimizerSocGoalEnabled(): boolean {
+			return (
+				this.batteryOptimizerSocGoal !== null && this.batteryOptimizerSocGoal !== undefined
+			);
+		},
+		batteryOptimizerSocGoalOptions() {
+			const options = [];
+			for (let i = 100; i >= 5; i -= 5) {
+				options.push({ value: i, name: this.fmtSoc(i) });
+			}
+			return options;
+		},
 	},
 	watch: {
 		prioritySoc: {
@@ -174,6 +244,18 @@ export default defineComponent({
 		bufferStartSoc: {
 			handler(soc) {
 				this.selectedBufferStartSoc = soc;
+			},
+			immediate: true,
+		},
+		batteryOptimizerSocGoal: {
+			handler(goal) {
+				this.selectedBatteryOptimizerSocGoal = goal ?? 20;
+			},
+			immediate: true,
+		},
+		batteryOptimizerSocGoalTime: {
+			handler(time) {
+				this.selectedBatteryOptimizerSocGoalTime = time || "21:00";
 			},
 			immediate: true,
 		},
@@ -229,6 +311,39 @@ export default defineComponent({
 			} catch (err) {
 				console.error(err);
 			}
+		},
+		async changeBatteryOptimizerSocGoalEnabled(e: Event) {
+			const enabled = (e.target as HTMLInputElement).checked;
+			try {
+				if (!enabled) {
+					await api.delete("batteryoptimizersocgoal");
+					return;
+				}
+				await this.saveBatteryOptimizerSocGoal();
+			} catch (err) {
+				console.error(err);
+			}
+		},
+		async changeBatteryOptimizerSocGoal() {
+			try {
+				await this.saveBatteryOptimizerSocGoal();
+			} catch (err) {
+				console.error(err);
+			}
+		},
+		async changeBatteryOptimizerSocGoalTime() {
+			try {
+				await this.saveBatteryOptimizerSocGoal();
+			} catch (err) {
+				console.error(err);
+			}
+		},
+		async saveBatteryOptimizerSocGoal() {
+			await api.post("batteryoptimizersocgoal", {
+				soc: this.selectedBatteryOptimizerSocGoal,
+				time: this.selectedBatteryOptimizerSocGoalTime,
+				tz: this.timezone(),
+			});
 		},
 		getBufferStartName(value: number) {
 			const key = value === 0 ? "never" : value === 100 ? "full" : "above";

--- a/assets/js/components/Battery/BatteryExperimental.vue
+++ b/assets/js/components/Battery/BatteryExperimental.vue
@@ -16,6 +16,8 @@
 			:priority-soc="state.prioritySoc"
 			:buffer-start-soc="state.bufferStartSoc"
 			:battery-discharge-control="state.batteryDischargeControl"
+			:battery-optimizer-soc-goal="state.batteryOptimizerSocGoal"
+			:battery-optimizer-soc-goal-time="state.batteryOptimizerSocGoalTime"
 			:battery="state.battery"
 		/>
 

--- a/assets/js/components/Battery/BatteryUsageSettings.vue
+++ b/assets/js/components/Battery/BatteryUsageSettings.vue
@@ -198,21 +198,6 @@
 						</label>
 					</div>
 				</div>
-				<div class="form-check form-switch">
-					<input
-						id="optimizerDischargeToGrid"
-						:checked="optimizerDischargeToGrid"
-						class="form-check-input"
-						type="checkbox"
-						role="switch"
-						@change="changeOptimizerDischargeToGrid"
-					/>
-					<div class="form-check-label">
-						<label for="optimizerDischargeToGrid">
-							{{ $t("batterySettings.optimizerDischargeToGrid") }}
-						</label>
-					</div>
-				</div>
 				<div class="border-top pt-3">
 					<div class="form-check form-switch mb-3">
 						<input
@@ -255,61 +240,6 @@
 						{{ $t("batterySettings.optimizerPA.hint") }}
 					</small>
 				</div>
-				<div class="border-top pt-3 mt-3">
-					<div class="form-check form-switch mb-3">
-						<input
-							id="batteryOptimizerSocGoalEnabled"
-							:checked="batteryOptimizerSocGoalEnabled"
-							class="form-check-input"
-							type="checkbox"
-							role="switch"
-							@change="changeBatteryOptimizerSocGoalEnabled"
-						/>
-						<div class="form-check-label">
-							<label for="batteryOptimizerSocGoalEnabled">
-								{{ $t("batterySettings.optimizerSocGoal.enable") }}
-							</label>
-						</div>
-					</div>
-					<div class="row g-3 align-items-end">
-						<div class="col-sm-6">
-							<label class="form-label" for="batteryOptimizerSocGoalTime">
-								{{ $t("batterySettings.optimizerSocGoal.time") }}
-							</label>
-							<input
-								id="batteryOptimizerSocGoalTime"
-								v-model="selectedBatteryOptimizerSocGoalTime"
-								type="time"
-								class="form-control mx-0"
-								:disabled="!batteryOptimizerSocGoalEnabled"
-								@change="changeBatteryOptimizerSocGoalTime"
-							/>
-						</div>
-						<div class="col-sm-6">
-							<label class="form-label" for="batteryOptimizerSocGoal">
-								{{ $t("batterySettings.optimizerSocGoal.soc") }}
-							</label>
-							<select
-								id="batteryOptimizerSocGoal"
-								v-model="selectedBatteryOptimizerSocGoal"
-								class="form-select"
-								:disabled="!batteryOptimizerSocGoalEnabled"
-								@change="changeBatteryOptimizerSocGoal"
-							>
-								<option
-									v-for="option in batteryOptimizerSocGoalOptions"
-									:key="option.value"
-									:value="option.value"
-								>
-									{{ option.name }}
-								</option>
-							</select>
-						</div>
-					</div>
-					<small class="d-block text-muted mt-2">
-						{{ $t("batterySettings.optimizerSocGoal.hint") }}
-					</small>
-				</div>
 			</div>
 		</div>
 	</div>
@@ -334,10 +264,7 @@ export default defineComponent({
 		prioritySoc: { type: Number, default: 0 },
 		bufferStartSoc: { type: Number, default: 0 },
 		batteryDischargeControl: Boolean,
-		optimizerDischargeToGrid: Boolean,
 		optimizerManualPA: { type: [Number, null] as PropType<number | null>, default: null },
-		batteryOptimizerSocGoal: { type: [Number, null] as PropType<number | null>, default: null },
-		batteryOptimizerSocGoalTime: { type: String, default: "21:00" },
 		currency: String as PropType<CURRENCY>,
 		battery: { type: Object as PropType<Battery> },
 	},
@@ -348,8 +275,6 @@ export default defineComponent({
 			selectedBufferStartSoc: 0,
 			selectedOptimizerManualPA: "",
 			optimizerManualPAEnabled: false,
-			selectedBatteryOptimizerSocGoal: 20,
-			selectedBatteryOptimizerSocGoalTime: "21:00",
 		};
 	},
 	computed: {
@@ -380,18 +305,6 @@ export default defineComponent({
 					name: this.fmtSoc(i),
 					disabled: i < this.selectedPrioritySoc,
 				});
-			}
-			return options;
-		},
-		batteryOptimizerSocGoalEnabled() {
-			return (
-				this.batteryOptimizerSocGoal !== null && this.batteryOptimizerSocGoal !== undefined
-			);
-		},
-		batteryOptimizerSocGoalOptions() {
-			const options = [];
-			for (let i = 100; i >= 5; i -= 5) {
-				options.push({ value: i, name: this.fmtSoc(i) });
 			}
 			return options;
 		},
@@ -489,12 +402,6 @@ export default defineComponent({
 				);
 			}
 		},
-		batteryOptimizerSocGoal(goal) {
-			this.selectedBatteryOptimizerSocGoal = goal ?? 20;
-		},
-		batteryOptimizerSocGoalTime(time) {
-			this.selectedBatteryOptimizerSocGoalTime = time || "21:00";
-		},
 	},
 	mounted() {
 		this.selectedBufferSoc = this.bufferSoc || 100;
@@ -507,8 +414,6 @@ export default defineComponent({
 				this.optimizerManualPA * this.pricePerKWhDisplayFactor(this.currency)
 			);
 		}
-		this.selectedBatteryOptimizerSocGoal = this.batteryOptimizerSocGoal ?? 20;
-		this.selectedBatteryOptimizerSocGoalTime = this.batteryOptimizerSocGoalTime || "21:00";
 	},
 	methods: {
 		changeBufferStart($event: Event) {
@@ -585,15 +490,6 @@ export default defineComponent({
 				console.error(err);
 			}
 		},
-		async changeOptimizerDischargeToGrid(e: Event) {
-			try {
-				await api.post(
-					`optimizerdischargetogrid/${(e.target as HTMLInputElement).checked ? "true" : "false"}`
-				);
-			} catch (err) {
-				console.error(err);
-			}
-		},
 		async changeOptimizerManualPAEnabled(e: Event) {
 			const enabled = (e.target as HTMLInputElement).checked;
 			this.optimizerManualPAEnabled = enabled;
@@ -626,39 +522,6 @@ export default defineComponent({
 
 			const baseValue = value / this.pricePerKWhDisplayFactor(this.currency);
 			await api.post(`optimizermanualpa/${encodeURIComponent(baseValue)}`);
-		},
-		async changeBatteryOptimizerSocGoalEnabled(e: Event) {
-			const enabled = (e.target as HTMLInputElement).checked;
-			try {
-				if (!enabled) {
-					await api.delete("batteryoptimizersocgoal");
-					return;
-				}
-				await this.saveBatteryOptimizerSocGoal();
-			} catch (err) {
-				console.error(err);
-			}
-		},
-		async changeBatteryOptimizerSocGoal() {
-			try {
-				await this.saveBatteryOptimizerSocGoal();
-			} catch (err) {
-				console.error(err);
-			}
-		},
-		async changeBatteryOptimizerSocGoalTime() {
-			try {
-				await this.saveBatteryOptimizerSocGoal();
-			} catch (err) {
-				console.error(err);
-			}
-		},
-		async saveBatteryOptimizerSocGoal() {
-			await api.post("batteryoptimizersocgoal", {
-				soc: this.selectedBatteryOptimizerSocGoal,
-				time: this.selectedBatteryOptimizerSocGoalTime,
-				tz: this.timezone(),
-			});
 		},
 		getBufferStartName(value: number) {
 			const key = value === 0 ? "never" : value === 100 ? "full" : "above";

--- a/assets/js/components/Optimize/OptimizeHeader.stories.ts
+++ b/assets/js/components/Optimize/OptimizeHeader.stories.ts
@@ -16,6 +16,7 @@ const base = {
   currency: CURRENCY.EUR,
   chargingStrategies: ["charge_before_export", "attenuate_grid_peaks", "none"],
   selectedStrategy: "charge_before_export",
+  dischargeToGrid: true,
   pending: false,
 };
 

--- a/assets/js/components/Optimize/OptimizeHeader.vue
+++ b/assets/js/components/Optimize/OptimizeHeader.vue
@@ -37,6 +37,22 @@
 						>
 					</CustomSelect>
 				</div>
+				<div class="field-extra form-check form-switch mt-2 mb-0">
+					<input
+						id="optimizerDischargeToGrid"
+						:checked="dischargeToGrid"
+						class="form-check-input"
+						type="checkbox"
+						role="switch"
+						@change="onDischargeChange"
+					/>
+					<label
+						class="form-check-label small text-lowercase evcc-gray"
+						for="optimizerDischargeToGrid"
+					>
+						discharge to grid
+					</label>
+				</div>
 			</div>
 
 			<!-- Result -->
@@ -154,9 +170,10 @@ export default defineComponent({
 		currency: { type: String as PropType<CURRENCY>, default: CURRENCY.EUR },
 		chargingStrategies: { type: Array as PropType<string[]>, default: () => [] },
 		selectedStrategy: { type: String, default: "" },
+		dischargeToGrid: { type: Boolean, default: false },
 		pending: { type: Boolean, default: false },
 	},
-	emits: ["optimize", "change-strategy"],
+	emits: ["optimize", "change-strategy", "change-discharge-to-grid"],
 	data() {
 		return {
 			tooltips: [] as Tooltip[],
@@ -206,6 +223,9 @@ export default defineComponent({
 		onStrategyChange(e: Event) {
 			this.$emit("change-strategy", (e.target as HTMLSelectElement).value);
 		},
+		onDischargeChange(e: Event) {
+			this.$emit("change-discharge-to-grid", (e.target as HTMLInputElement).checked);
+		},
 		initTooltips() {
 			const items: [Element | undefined, string][] = [
 				[this.$refs["statusInfo"] as Element | undefined, STATUS_TOOLTIP],
@@ -245,11 +265,17 @@ export default defineComponent({
 /* small: each field a full-width row (Bootstrap col-12), label left, value right */
 .field {
 	display: flex;
+	flex-wrap: wrap;
 	justify-content: space-between;
 	align-items: center;
 	gap: 1rem;
 	padding: 0.75rem 0;
 	border-top: 1px solid var(--evcc-gray-25);
+}
+/* discharge toggle: always render last, on its own full-width line */
+.field-extra {
+	order: 3;
+	width: 100%;
 }
 .field:last-child {
 	border-bottom: 1px solid var(--evcc-gray-25);
@@ -283,6 +309,7 @@ export default defineComponent({
 @media (min-width: 768px) {
 	.field {
 		flex-direction: column;
+		flex-wrap: nowrap;
 		justify-content: flex-start;
 		align-items: flex-start;
 		gap: 0;

--- a/assets/js/views/Optimize.vue
+++ b/assets/js/views/Optimize.vue
@@ -10,9 +10,11 @@
 			:currency="currency"
 			:charging-strategies="chargingStrategies"
 			:selected-strategy="optimizerChargingStrategy"
+			:discharge-to-grid="optimizerDischargeToGrid"
 			:pending="pending"
 			@optimize="optimizeNow"
 			@change-strategy="changeChargingStrategy"
+			@change-discharge-to-grid="changeDischargeToGrid"
 		/>
 		<div class="row">
 			<main class="col-12">
@@ -177,6 +179,9 @@ export default defineComponent({
 		optimizerChargingStrategy(): string {
 			return store.state.optimizerChargingStrategy || "";
 		},
+		optimizerDischargeToGrid(): boolean {
+			return !!store.state.optimizerDischargeToGrid;
+		},
 		netCost(): number {
 			return (this.evopt?.res?.objective_value || 0) * -1;
 		},
@@ -226,6 +231,9 @@ export default defineComponent({
 		},
 		changeChargingStrategy(value: string) {
 			api.post(`optimizerchargingstrategy/${value}`);
+		},
+		changeDischargeToGrid(value: boolean) {
+			api.post(`optimizerdischargetogrid/${value}`);
 		},
 		dimColorBy25Percent(color: string): string {
 			// Convert color to 25% opacity (40 in hex = 25% of 255)


### PR DESCRIPTION
## Context

evcc 0.311.0 redesigned the battery tab, moving usage controls into new components (`BatteryConfigCard` / `BatteryExperimental`). That left the fork's two battery-tab customisations stranded on the classic `BatteryUsageSettings`. This moves each to where it belongs on the new design.

Backend endpoints (`optimizerdischargetogrid`, `batteryoptimizersocgoal`) and state are unchanged — this is purely a frontend relocation.

## Changes

**1. "Allow discharge to grid" → optimizer page**
Added as a toggle inside the **Secondary goal** box of `OptimizeHeader.vue` (under the strategy selector). `Optimize.vue` passes the state and posts to the existing `optimizerdischargetogrid` endpoint, mirroring the strategy handler.

**2. "Daily reserve target" (battery SoC goal) → new battery page**
Added to `BatteryConfigCard.vue` (the redesigned usage card rendered by `BatteryExperimental.vue`): enable toggle + time + reserve-target select + hint, fed from store state. Reuses the existing `batterySettings.optimizerSocGoal.*` i18n and the `batteryoptimizersocgoal` endpoint.

**3. Cleanup**
Both settings removed from the classic `BatteryUsageSettings.vue` (props/data/computed/watchers/methods). Manual PA is intentionally left there for now (out of scope).

## Verification

- `vue-tsc` 0 errors, eslint + prettier clean.
- Visually verified via Storybook screenshots (wide + mobile):
  - discharge toggle sits cleanly within the Secondary goal box, wrapping to its own line without overflowing the adjacent boxes;
  - daily reserve target renders correctly in the new battery card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)