### PR TITLE
Optimizer: consolidate duplicate force-update paths

### DIFF
--- a/core/site_api.go
+++ b/core/site_api.go
@@ -392,8 +392,8 @@ func (site *Site) SetOptimizerDischargeToGrid(val bool) error {
 	}
 	site.Unlock()
 
-	if changed && sponsor.IsAuthorized() && optimizerEnabled() {
-		go site.optimizerUpdateAsyncWithForce(true)
+	if changed {
+		site.triggerOptimizer()
 	}
 
 	return nil
@@ -426,8 +426,8 @@ func (site *Site) SetOptimizerManualPA(val *float64) error {
 	}
 	site.Unlock()
 
-	if changed && sponsor.IsAuthorized() && optimizerEnabled() {
-		go site.optimizerUpdateAsyncWithForce(true)
+	if changed {
+		site.triggerOptimizer()
 	}
 
 	return nil
@@ -505,8 +505,8 @@ func (site *Site) SetBatteryOptimizerSocGoal(val *float64) error {
 	}
 	site.Unlock()
 
-	if changed && sponsor.IsAuthorized() && optimizerEnabled() {
-		go site.optimizerUpdateAsyncWithForce(true)
+	if changed {
+		site.triggerOptimizer()
 	}
 
 	return nil
@@ -551,8 +551,8 @@ func (site *Site) SetBatteryOptimizerSocGoalTime(val string) error {
 	}
 	site.Unlock()
 
-	if changed && sponsor.IsAuthorized() && optimizerEnabled() {
-		go site.optimizerUpdateAsyncWithForce(true)
+	if changed {
+		site.triggerOptimizer()
 	}
 
 	return nil
@@ -582,8 +582,8 @@ func (site *Site) SetBatteryOptimizerSocGoalTimezone(val string) error {
 	}
 	site.Unlock()
 
-	if changed && sponsor.IsAuthorized() && optimizerEnabled() {
-		go site.optimizerUpdateAsyncWithForce(true)
+	if changed {
+		site.triggerOptimizer()
 	}
 
 	return nil

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -119,20 +119,13 @@ const slotsPerHour = float64(time.Hour / tariff.SlotDuration)
 var errOptimizerNotReady = errors.New("battery measurements not ready")
 
 func (site *Site) optimizerUpdateAsync() {
-	site.optimizerUpdateAsyncWithForce(false)
-}
-
-func shouldSkipOptimizerUpdate(force bool, updated, now time.Time) bool {
-	return !force && now.Sub(updated) < 2*time.Minute
-}
-
-func (site *Site) optimizerUpdateAsyncWithForce(force bool) {
 	if !mu.TryLock() {
 		return
 	}
 	defer mu.Unlock()
 
-	if shouldSkipOptimizerUpdate(force, optimizerUpdated, time.Now()) {
+	// slot/debounce gate; triggerOptimizer bypasses it by zeroing optimizerUpdated
+	if time.Since(optimizerUpdated) < 2*time.Minute {
 		return
 	}
 


### PR DESCRIPTION
## Problem

There were **two** implementations of "force the optimizer to rerun now, bypassing the 2-minute debounce":

| Mechanism | Origin | Used by |
|---|---|---|
| `triggerOptimizer()` | **upstream** (`#30782`, in 0.311.0) | charging-strategy setter |
| `optimizerUpdateAsyncWithForce(true)` + `shouldSkipOptimizerUpdate` | **fork** (`2a6029dcf`, Apr 2026) | discharge-to-grid, manual PA, SoC-goal setters (5 sites) |

The fork added its version first; upstream later added `triggerOptimizer()`, which arrived via the 0.311.0 sync — leaving both in the tree.

## Change

Standardise on upstream's `triggerOptimizer()`:
- The 5 fork call sites now call `site.triggerOptimizer()` instead of `go site.optimizerUpdateAsyncWithForce(true)`. The per-site `sponsor.IsAuthorized() && optimizerEnabled()` guard is dropped because `triggerOptimizer()` already performs it.
- `optimizerUpdateAsync()` is folded back to its canonical inline-debounce form; `optimizerUpdateAsyncWithForce` and `shouldSkipOptimizerUpdate` are removed.

Behavior is unchanged — both mechanisms zeroed/skipped the same debounce gate to rerun immediately. Now all six setters share one path.

## Verification

`go build`, `go vet`, and `go test ./core/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)