### PR TITLE
CI: auto-increment point-release tag suffix on sync finalize

### DIFF
--- a/.github/workflows/sync-tags-pr.yml
+++ b/.github/workflows/sync-tags-pr.yml
@@ -49,13 +49,25 @@ jobs:
           # Checkout the branch that was merged
           git checkout "${{ env.BRANCH }}"
 
-          # Create the new tag
-          NEW_TAG="${{ steps.validate-branch.outputs.BRANCH }}.0"
+          # Base version derived from the tag branch, e.g. 0.311.0
+          BASE="${{ steps.validate-branch.outputs.BRANCH }}"
 
-          # Tag the branch
+          # Pick the next free point-release suffix: BASE.0, BASE.1, BASE.2, ...
+          # Re-merges to the same tag branch auto-increment instead of colliding
+          # with an existing tag (which previously failed the job).
+          git fetch --tags --force
+          MAX=-1
+          for t in $(git tag -l "${BASE}.*"); do
+            N="${t##*.}"
+            if [[ "$N" =~ ^[0-9]+$ ]] && [ "$N" -gt "$MAX" ]; then
+              MAX="$N"
+            fi
+          done
+          NEW_TAG="${BASE}.$((MAX + 1))"
+          echo "Creating tag ${NEW_TAG}"
+
+          # Tag the branch and push
           git tag "${NEW_TAG}"
-
-          # Push the tag to the repository
           git push origin "${NEW_TAG}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

`sync-tags-pr.yml`'s finalize step hard-codes the new tag as `<version>.0`:

```bash
NEW_TAG="${{ steps.validate-branch.outputs.BRANCH }}.0"
git tag "${NEW_TAG}"
```

So a **second** release off the same tag branch (e.g. merging another PR into `tag-0.311.0` when `0.311.0.0` already exists) fails with *"tag already exists"* and creates no tag. That's the failure on [run 28837005721](https://github.com/jeffborg/evcc/actions/runs/28837005721/job/85522801329) — `NEW_TAG="0.311.0.0"` collided.

## Fix

Pick the next free point-release suffix by scanning existing `<version>.N` tags and incrementing the highest:

```bash
git fetch --tags --force
MAX=-1
for t in $(git tag -l "${BASE}.*"); do
  N="${t##*.}"
  if [[ "$N" =~ ^[0-9]+$ ]] && [ "$N" -gt "$MAX" ]; then MAX="$N"; fi
done
NEW_TAG="${BASE}.$((MAX + 1))"
```

So merges produce `.0, .1, .2, …` automatically; a fresh tag branch still starts at `.0`. No more manual tagging or collisions.

Verified: YAML + `bash -n` valid; simulated against the live tags — with `0.311.0.0`/`0.311.0.1` present it computes `0.311.0.2`, and a brand-new `0.312.0` branch computes `0.312.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)