### PR TITLE
UI: clip extreme price spikes on the charts (fixed $/kWh threshold)

### DIFF
--- a/assets/js/components/Forecast/PriceChart.vue
+++ b/assets/js/components/Forecast/PriceChart.vue
@@ -23,7 +23,7 @@ import {
 import colors, { lighterColor } from "@/colors";
 import formatter from "@/mixins/formatter";
 import chartMixin from "./chartMixin";
-import { robustPriceMax } from "@/utils/robustPriceMax";
+import { robustPriceMax, PRICE_SPIKE_CLIP } from "@/utils/robustPriceMax";
 import type { CURRENCY } from "@/types/evcc";
 import type { ForecastSlot } from "./types";
 
@@ -71,9 +71,9 @@ export default defineComponent({
 				...this.feedinSlots.map((s) => s.value),
 			];
 			const dataMin = Math.min(...values);
-			// cap the top at a robust percentile so rare price spikes don't flatten
-			// the everyday range (spikes clip at the axis max; tooltip shows the real value)
-			const dataMax = robustPriceMax(values);
+			// clip prices above the spike threshold so they don't flatten the everyday
+			// range (spikes clip at the axis max; tooltip shows the real value)
+			const dataMax = robustPriceMax(values, { threshold: PRICE_SPIKE_CLIP });
 			const rangeMin = this.zoom ? dataMin : Math.min(0, dataMin);
 			const rangeMax = Math.max(0, dataMax);
 			const range = rangeMax - rangeMin || 1;

--- a/assets/js/components/Forecast/PriceChart.vue
+++ b/assets/js/components/Forecast/PriceChart.vue
@@ -23,6 +23,7 @@ import {
 import colors, { lighterColor } from "@/colors";
 import formatter from "@/mixins/formatter";
 import chartMixin from "./chartMixin";
+import { robustPriceMax } from "@/utils/robustPriceMax";
 import type { CURRENCY } from "@/types/evcc";
 import type { ForecastSlot } from "./types";
 
@@ -70,7 +71,9 @@ export default defineComponent({
 				...this.feedinSlots.map((s) => s.value),
 			];
 			const dataMin = Math.min(...values);
-			const dataMax = Math.max(...values);
+			// cap the top at a robust percentile so rare price spikes don't flatten
+			// the everyday range (spikes clip at the axis max; tooltip shows the real value)
+			const dataMax = robustPriceMax(values);
 			const rangeMin = this.zoom ? dataMin : Math.min(0, dataMin);
 			const rangeMax = Math.max(0, dataMax);
 			const range = rangeMax - rangeMin || 1;

--- a/assets/js/components/Forecast/PriceChart.vue
+++ b/assets/js/components/Forecast/PriceChart.vue
@@ -88,6 +88,14 @@ export default defineComponent({
 				interval,
 			};
 		},
+		// resolved danger colour used to flag spikes clipped at the axis ceiling
+		spikeColor(): string {
+			if (typeof getComputedStyle === "undefined") return "#dc3545";
+			return (
+				getComputedStyle(document.documentElement).getPropertyValue("--bs-danger").trim() ||
+				"#dc3545"
+			);
+		},
 		chartOption(): Record<string, unknown> {
 			const priceColor = colors.price || "";
 			const exportColor = colors.export || "";
@@ -103,7 +111,9 @@ export default defineComponent({
 					trigger: "axis",
 					axisPointer: { type: "line", snap: true, lineStyle: { color: "transparent" } },
 					...tooltipStyle(priceColor, () => this.chart),
-					formatter(params: { value: [string, number]; seriesIndex: number }[]) {
+					formatter(allParams: { value: [string, number]; seriesIndex: number }[]) {
+						// price + feed-in are series 0/1; ignore the spike-marker scatters
+						const params = allParams.filter((s) => s.seriesIndex < 2);
 						const p = params[0];
 						if (!p) return "";
 						const d = new Date(p.value[0]);
@@ -137,11 +147,35 @@ export default defineComponent({
 				series: [
 					this.priceSeries(this.slots, priceColor, this.markPoints),
 					this.priceSeries(this.feedinSlots, exportColor),
+					...this.spikeMarkers(this.slots),
+					...this.spikeMarkers(this.feedinSlots),
 				],
 			};
 		},
 	},
 	methods: {
+		// dots at the axis ceiling flag slots whose price is clipped above the
+		// robust max, so a spike is distinct from a legit top-of-range price
+		spikeMarkers(slots: ForecastSlot[]): Record<string, unknown>[] {
+			const cap = this.yAxisConfig["max"] as number | undefined;
+			if (cap == null) return [];
+			const clipped = slots.filter((s) => s.value > cap);
+			if (!clipped.length) return [];
+			return [
+				{
+					type: "scatter",
+					symbol: "circle",
+					symbolSize: 6,
+					cursor: "default",
+					silent: true,
+					z: 5,
+					data: clipped.map((s) => ({
+						value: [clampStart(s.start, this.startDate), cap],
+					})),
+					itemStyle: { color: this.spikeColor },
+				},
+			];
+		},
 		priceSeries(
 			slots: ForecastSlot[],
 			color: string,

--- a/assets/js/components/Optimize/PriceChart.vue
+++ b/assets/js/components/Optimize/PriceChart.vue
@@ -86,12 +86,21 @@ export default defineComponent({
 			const ts = this.evopt?.req?.time_series;
 			if (!ts) return undefined;
 			const missing = this.gridForecastMissing || [];
-			const convert = (p: number) => p * 1000;
+			const factor = this.pricePerKWhDisplayFactor(this.currency);
+			const convert = (p: number) => p * 1000 * factor;
 			const values = [
 				...(ts.p_N || []).filter((_, i) => !missing[i]).map(convert),
 				...(ts.p_E || []).map(convert),
 			];
 			return values.length ? robustPriceMax(values) : undefined;
+		},
+		// resolved danger colour used to flag spikes clipped at the axis ceiling
+		spikeColor(): string {
+			if (typeof getComputedStyle === "undefined") return "#dc3545";
+			return (
+				getComputedStyle(document.documentElement).getPropertyValue("--bs-danger").trim() ||
+				"#dc3545"
+			);
 		},
 		timeLabels(): string[] {
 			const startTime = new Date(this.timestamp);
@@ -270,14 +279,19 @@ export default defineComponent({
 			const factor = this.pricePerKWhDisplayFactor(this.currency);
 			const convertPrice = (price: number): number => price * 1000 * factor;
 
+			const cap = this.priceAxisMax;
+			// a point sits above the axis cap -> it's a clipped spike; mark it
+			const clipped = (v: number | null) => v != null && cap != null && v > cap;
+
 			// Grid Import Price (solid line, price color)
 			// Slots without a real planner tariff are filled with a fallback rate on
 			// the backend; gap those points so the fallback value is not drawn.
+			const importData = this.evopt.req.time_series.p_N.map((price, index) =>
+				this.gridForecastMissing[index] ? null : convertPrice(price)
+			);
 			datasets.push({
 				label: "Import",
-				data: this.evopt.req.time_series.p_N.map((price, index) =>
-					this.gridForecastMissing[index] ? null : convertPrice(price)
-				),
+				data: importData,
 				borderColor: colors.grid,
 				backgroundColor: colors.grid,
 				fill: false,
@@ -285,7 +299,13 @@ export default defineComponent({
 				stepped: true,
 				borderJoinStyle: "round",
 				borderCapStyle: "round",
-				pointRadius: 0,
+				pointRadius: importData.map((v) => (clipped(v) ? 3.5 : 0)),
+				pointBackgroundColor: importData.map((v) =>
+					clipped(v) ? this.spikeColor : colors.grid
+				),
+				pointBorderColor: importData.map((v) =>
+					clipped(v) ? this.spikeColor : colors.grid
+				),
 				pointHoverRadius: 6,
 				borderWidth: 2,
 				yAxisID: "y",
@@ -293,17 +313,24 @@ export default defineComponent({
 			});
 
 			// Grid Export Price (solid line, price color)
+			const exportData = this.evopt.req.time_series.p_E.map(convertPrice);
 			datasets.push({
 				label: "Export",
-				data: this.evopt.req.time_series.p_E.map(convertPrice),
+				data: exportData,
 				borderColor: colors.price,
 				backgroundColor: colors.price,
+				pointRadius: exportData.map((v) => (clipped(v) ? 3.5 : 0)),
+				pointBackgroundColor: exportData.map((v) =>
+					clipped(v) ? this.spikeColor : colors.price
+				),
+				pointBorderColor: exportData.map((v) =>
+					clipped(v) ? this.spikeColor : colors.price
+				),
 				fill: false,
 				tension,
 				stepped: true,
 				borderJoinStyle: "round",
 				borderCapStyle: "round",
-				pointRadius: 0,
 				pointHoverRadius: 6,
 				borderWidth: 2,
 				yAxisID: "y",

--- a/assets/js/components/Optimize/PriceChart.vue
+++ b/assets/js/components/Optimize/PriceChart.vue
@@ -36,6 +36,7 @@ import colors from "@/colors";
 import LegendList from "../Sessions/LegendList.vue";
 import type { Legend } from "../Sessions/types";
 import { syncChartTooltip } from "./chartSync";
+import { robustPriceMax } from "@/utils/robustPriceMax";
 
 const tension = 0;
 
@@ -81,6 +82,17 @@ export default defineComponent({
 	},
 	emits: ["hover-index"],
 	computed: {
+		priceAxisMax(): number | undefined {
+			const ts = this.evopt?.req?.time_series;
+			if (!ts) return undefined;
+			const missing = this.gridForecastMissing || [];
+			const convert = (p: number) => p * 1000;
+			const values = [
+				...(ts.p_N || []).filter((_, i) => !missing[i]).map(convert),
+				...(ts.p_E || []).map(convert),
+			];
+			return values.length ? robustPriceMax(values) : undefined;
+		},
 		timeLabels(): string[] {
 			const startTime = new Date(this.timestamp);
 			return this.evopt.req.time_series.dt.map((_, index) => {
@@ -214,7 +226,9 @@ export default defineComponent({
 						grid: {
 							drawOnChartArea: true,
 						},
-						// Keep scales purely based on values, no fixed boundaries
+						// cap the top at a robust percentile so rare price spikes don't
+						// flatten the everyday range (tooltip still shows the real value)
+						max: this.priceAxisMax,
 					},
 				},
 			};

--- a/assets/js/components/Optimize/PriceChart.vue
+++ b/assets/js/components/Optimize/PriceChart.vue
@@ -36,7 +36,7 @@ import colors from "@/colors";
 import LegendList from "../Sessions/LegendList.vue";
 import type { Legend } from "../Sessions/types";
 import { syncChartTooltip } from "./chartSync";
-import { robustPriceMax } from "@/utils/robustPriceMax";
+import { robustPriceMax, PRICE_SPIKE_CLIP } from "@/utils/robustPriceMax";
 
 const tension = 0;
 
@@ -92,7 +92,10 @@ export default defineComponent({
 				...(ts.p_N || []).filter((_, i) => !missing[i]).map(convert),
 				...(ts.p_E || []).map(convert),
 			];
-			return values.length ? robustPriceMax(values) : undefined;
+			// values are in display units (e.g. cents), so scale the base threshold
+			return values.length
+				? robustPriceMax(values, { threshold: PRICE_SPIKE_CLIP * factor })
+				: undefined;
 		},
 		// resolved danger colour used to flag spikes clipped at the axis ceiling
 		spikeColor(): string {

--- a/assets/js/components/Tariff/TariffChart.vue
+++ b/assets/js/components/Tariff/TariffChart.vue
@@ -28,7 +28,10 @@
 				<div
 					class="slot-bar"
 					:style="valueStyle(slot.value)"
-					:class="{ unknown: slot.value === undefined && avgValue }"
+					:class="{
+						unknown: slot.value === undefined && avgValue,
+						clipped: isClipped(slot.value),
+					}"
 				></div>
 				<div class="slot-label">
 					<span v-if="slot.start.getMinutes() === 0 && slot.start.getHours() % 2 === 0">{{
@@ -63,6 +66,7 @@ import "@h2d2/shopicons/es/regular/arrowright";
 import { is12hFormat } from "@/units";
 import PlanEndIcon from "../MaterialIcon/PlanEnd.vue";
 import formatter from "@/mixins/formatter";
+import { robustPriceMax } from "@/utils/robustPriceMax";
 import type { Slot } from "@/types/evcc";
 const BAR_WIDTH = 8;
 
@@ -89,16 +93,17 @@ export default defineComponent({
 	},
 	computed: {
 		valueInfo() {
-			let max = Number.MIN_VALUE;
-			let min = 0;
-			this.slots
+			const values = this.slots
 				.map((s) => s.value)
-				.filter((value) => value !== undefined)
-				.forEach((value) => {
-					max = Math.max(max, value);
-					min = Math.min(min, value);
-				});
-			return { min, range: max - min };
+				.filter((value): value is number => value !== undefined);
+			let min = 0;
+			values.forEach((value) => {
+				min = Math.min(min, value);
+			});
+			// cap the top at a robust percentile so rare price spikes don't flatten
+			// the everyday range; spike bars clip at full height (see valueStyle)
+			const max = values.length ? robustPriceMax(values) : 0;
+			return { min, max, range: max - min || 1 };
 		},
 		targetLeft() {
 			return `${(this.targetOffset / 0.25) * BAR_WIDTH}px`;
@@ -152,11 +157,15 @@ export default defineComponent({
 		},
 		valueStyle(value: number | undefined) {
 			const val = value === undefined ? this.avgValue : value;
-			const height =
-				value !== undefined && !isNaN(val)
-					? `${10 + (90 / this.valueInfo.range) * (val - this.valueInfo.min)}%`
-					: "50%";
-			return { height };
+			if (value === undefined || isNaN(val)) {
+				return { height: "50%" };
+			}
+			const raw = 10 + (90 / this.valueInfo.range) * (val - this.valueInfo.min);
+			// clip spikes above the robust max to full height
+			return { height: `${Math.min(100, raw)}%` };
+		},
+		isClipped(value: number | undefined) {
+			return value !== undefined && value > this.valueInfo.max;
 		},
 		startLongPress(index: number) {
 			this.longPressTimer = setTimeout(() => {
@@ -249,6 +258,27 @@ export default defineComponent({
 	justify-content: center;
 	color: var(--bs-white);
 	transition: height var(--evcc-transition-fast) ease-in;
+}
+/* hatched cap marks a spike clipped above the chart's robust max */
+.slot-bar.clipped {
+	position: relative;
+}
+.slot-bar.clipped::after {
+	content: "";
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	height: 4px;
+	border-radius: 2px 2px 0 0;
+	background: repeating-linear-gradient(
+		-45deg,
+		var(--bs-white) 0,
+		var(--bs-white) 1px,
+		transparent 1px,
+		transparent 3px
+	);
+	opacity: 0.7;
 }
 .slot-bar.unknown {
 	opacity: 0.33;

--- a/assets/js/components/Tariff/TariffChart.vue
+++ b/assets/js/components/Tariff/TariffChart.vue
@@ -66,7 +66,7 @@ import "@h2d2/shopicons/es/regular/arrowright";
 import { is12hFormat } from "@/units";
 import PlanEndIcon from "../MaterialIcon/PlanEnd.vue";
 import formatter from "@/mixins/formatter";
-import { robustPriceMax } from "@/utils/robustPriceMax";
+import { robustPriceMax, PRICE_SPIKE_CLIP } from "@/utils/robustPriceMax";
 import type { Slot } from "@/types/evcc";
 const BAR_WIDTH = 8;
 
@@ -100,9 +100,9 @@ export default defineComponent({
 			values.forEach((value) => {
 				min = Math.min(min, value);
 			});
-			// cap the top at a robust percentile so rare price spikes don't flatten
-			// the everyday range; spike bars clip at full height (see valueStyle)
-			const max = values.length ? robustPriceMax(values) : 0;
+			// clip prices above the spike threshold so they don't flatten the
+			// everyday range; spike bars clip at full height (see valueStyle)
+			const max = values.length ? robustPriceMax(values, { threshold: PRICE_SPIKE_CLIP }) : 0;
 			return { min, max, range: max - min || 1 };
 		},
 		targetLeft() {

--- a/assets/js/utils/robustPriceMax.test.ts
+++ b/assets/js/utils/robustPriceMax.test.ts
@@ -1,44 +1,29 @@
 import { describe, expect, it } from "vitest";
-import { robustPriceMax } from "./robustPriceMax";
+import { robustPriceMax, PRICE_SPIKE_CLIP } from "./robustPriceMax";
 
 describe("robustPriceMax", () => {
-  // 48h of 30-min slots: mostly 5-50 c/kWh, with a 1h ($20 = 2000c) spike
-  const spiky = [
-    ...Array.from({ length: 94 }, (_, i) => 5 + (i % 45)), // ~5..49
-    2000,
-    2000, // 1h spike (2 slots)
-  ];
-
-  it("caps the axis well below the spike (P95)", () => {
-    const max = robustPriceMax(spiky, { percentile: 95 });
-    expect(max).toBeLessThan(100); // not 2000
-    expect(max).toBeGreaterThan(40); // still above the normal band
+  it("caps at the threshold when a spike exceeds it", () => {
+    // everyday 0.1..1.1 $/kWh with a 20 $/kWh spike
+    const vals = [0.1, 0.3, 0.6, 1.1, 20];
+    expect(robustPriceMax(vals, { threshold: 3 })).toBe(3);
   });
 
-  it("does not clip a calm day (peak within the everyday range)", () => {
-    const calm = Array.from({ length: 96 }, (_, i) => 5 + (i % 40)); // 5..44, no spike
-    expect(robustPriceMax(calm, { percentile: 95 })).toBe(Math.max(...calm));
+  it("does not clip legit peaks below the threshold", () => {
+    // max 1.1 is a high-but-real peak, not a spike -> full range
+    const vals = [0.1, 0.3, 0.6, 1.1];
+    expect(robustPriceMax(vals, { threshold: 3 })).toBe(1.1);
   });
 
-  it("returns true max when the peak only modestly exceeds the percentile", () => {
-    const gentle = [10, 12, 15, 18, 20, 22, 25, 30]; // 30 < 1.5 * P95
-    expect(robustPriceMax(gentle)).toBe(30);
+  it("returns the true max when no threshold is given", () => {
+    expect(robustPriceMax([0.1, 0.5, 20])).toBe(20);
   });
 
   it("ignores non-finite values and handles empty input", () => {
     expect(robustPriceMax([])).toBe(0);
-    expect(robustPriceMax([NaN, Infinity, 5, 10])).toBe(10);
+    expect(robustPriceMax([NaN, Infinity, 0.5, 20], { threshold: 3 })).toBe(3);
   });
 
-  it("percentile knob is honoured (P98 caps higher than P95)", () => {
-    expect(robustPriceMax(spiky, { percentile: 98 })).toBeGreaterThanOrEqual(
-      robustPriceMax(spiky, { percentile: 95 })
-    );
-  });
-
-  it("strips float artefacts from the headroomed cap", () => {
-    // P95 = 50, headroom 1.1 -> 50*1.1 = 55.00000000001 in float; must be clean
-    const vals = [...Array.from({ length: 95 }, () => 50), 2000];
-    expect(robustPriceMax(vals, { percentile: 95, headroom: 1.1 })).toBe(55);
+  it("exposes a sensible default spike threshold", () => {
+    expect(PRICE_SPIKE_CLIP).toBe(3);
   });
 });

--- a/assets/js/utils/robustPriceMax.test.ts
+++ b/assets/js/utils/robustPriceMax.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { robustPriceMax } from "./robustPriceMax";
+
+describe("robustPriceMax", () => {
+  // 48h of 30-min slots: mostly 5-50 c/kWh, with a 1h ($20 = 2000c) spike
+  const spiky = [
+    ...Array.from({ length: 94 }, (_, i) => 5 + (i % 45)), // ~5..49
+    2000,
+    2000, // 1h spike (2 slots)
+  ];
+
+  it("caps the axis well below the spike (P95)", () => {
+    const max = robustPriceMax(spiky, { percentile: 95 });
+    expect(max).toBeLessThan(100); // not 2000
+    expect(max).toBeGreaterThan(40); // still above the normal band
+  });
+
+  it("does not clip a calm day (peak within the everyday range)", () => {
+    const calm = Array.from({ length: 96 }, (_, i) => 5 + (i % 40)); // 5..44, no spike
+    expect(robustPriceMax(calm, { percentile: 95 })).toBe(Math.max(...calm));
+  });
+
+  it("returns true max when the peak only modestly exceeds the percentile", () => {
+    const gentle = [10, 12, 15, 18, 20, 22, 25, 30]; // 30 < 1.5 * P95
+    expect(robustPriceMax(gentle)).toBe(30);
+  });
+
+  it("ignores non-finite values and handles empty input", () => {
+    expect(robustPriceMax([])).toBe(0);
+    expect(robustPriceMax([NaN, Infinity, 5, 10])).toBe(10);
+  });
+
+  it("percentile knob is honoured (P98 caps higher than P95)", () => {
+    expect(robustPriceMax(spiky, { percentile: 98 })).toBeGreaterThanOrEqual(
+      robustPriceMax(spiky, { percentile: 95 })
+    );
+  });
+});

--- a/assets/js/utils/robustPriceMax.test.ts
+++ b/assets/js/utils/robustPriceMax.test.ts
@@ -35,4 +35,10 @@ describe("robustPriceMax", () => {
       robustPriceMax(spiky, { percentile: 95 })
     );
   });
+
+  it("strips float artefacts from the headroomed cap", () => {
+    // P95 = 50, headroom 1.1 -> 50*1.1 = 55.00000000001 in float; must be clean
+    const vals = [...Array.from({ length: 95 }, () => 50), 2000];
+    expect(robustPriceMax(vals, { percentile: 95, headroom: 1.1 })).toBe(55);
+  });
 });

--- a/assets/js/utils/robustPriceMax.ts
+++ b/assets/js/utils/robustPriceMax.ts
@@ -1,0 +1,38 @@
+// Robust upper bound for price charts.
+//
+// Dynamic tariffs (e.g. AU AEMO/Amber) occasionally spike from a few c/kWh to
+// $20/kWh. Auto-scaling the axis to that peak flattens the normal range into an
+// unreadable line. Instead we cap the axis at a high percentile so the everyday
+// range stays readable and the rare spikes clip at the top.
+//
+// The cap is only applied when the peak genuinely dwarfs the bulk of the data
+// (margin guard), so calm/elevated days without a spike still scale to their
+// true maximum and nothing is clipped.
+
+export interface RobustPriceMaxOptions {
+  percentile?: number; // axis cap percentile, default 95 (clips ~top 5% of slots)
+  margin?: number; // only clip when trueMax > margin * percentileValue, default 1.5
+}
+
+function percentileOf(sortedAsc: number[], p: number): number {
+  if (sortedAsc.length === 0) return 0;
+  const idx = Math.min(sortedAsc.length - 1, Math.max(0, Math.floor((p / 100) * sortedAsc.length)));
+  return sortedAsc[idx] as number;
+}
+
+/**
+ * Returns the value to use as the chart's upper bound: the percentile value when
+ * a dominant spike is present, otherwise the true maximum (no clipping).
+ */
+export function robustPriceMax(values: number[], opts: RobustPriceMaxOptions = {}): number {
+  const { percentile = 95, margin = 1.5 } = opts;
+  const finite = values.filter((v) => Number.isFinite(v));
+  if (finite.length === 0) return 0;
+
+  const trueMax = Math.max(...finite);
+  const sorted = [...finite].sort((a, b) => a - b);
+  const cap = percentileOf(sorted, percentile);
+
+  // clip only when the peak dwarfs the everyday range
+  return cap > 0 && trueMax > margin * cap ? cap : trueMax;
+}

--- a/assets/js/utils/robustPriceMax.ts
+++ b/assets/js/utils/robustPriceMax.ts
@@ -37,5 +37,9 @@ export function robustPriceMax(values: number[], opts: RobustPriceMaxOptions = {
 
   // clip only when the peak dwarfs the everyday range; lift by headroom so the
   // everyday band sits just below the ceiling and spikes clip visibly above it
-  return cap > 0 && trueMax > margin * cap ? cap * headroom : trueMax;
+  if (cap > 0 && trueMax > margin * cap) {
+    // toPrecision strips float artefacts (e.g. 55.00000000001) from the axis max
+    return Number((cap * headroom).toPrecision(12));
+  }
+  return trueMax;
 }

--- a/assets/js/utils/robustPriceMax.ts
+++ b/assets/js/utils/robustPriceMax.ts
@@ -12,6 +12,8 @@
 export interface RobustPriceMaxOptions {
   percentile?: number; // axis cap percentile, default 95 (clips ~top 5% of slots)
   margin?: number; // only clip when trueMax > margin * percentileValue, default 1.5
+  headroom?: number; // when clipping, lift the cap this much above the percentile so
+  // spikes clip *above* the everyday band (distinct), default 1.1
 }
 
 function percentileOf(sortedAsc: number[], p: number): number {
@@ -25,7 +27,7 @@ function percentileOf(sortedAsc: number[], p: number): number {
  * a dominant spike is present, otherwise the true maximum (no clipping).
  */
 export function robustPriceMax(values: number[], opts: RobustPriceMaxOptions = {}): number {
-  const { percentile = 95, margin = 1.5 } = opts;
+  const { percentile = 95, margin = 1.5, headroom = 1.1 } = opts;
   const finite = values.filter((v) => Number.isFinite(v));
   if (finite.length === 0) return 0;
 
@@ -33,6 +35,7 @@ export function robustPriceMax(values: number[], opts: RobustPriceMaxOptions = {
   const sorted = [...finite].sort((a, b) => a - b);
   const cap = percentileOf(sorted, percentile);
 
-  // clip only when the peak dwarfs the everyday range
-  return cap > 0 && trueMax > margin * cap ? cap : trueMax;
+  // clip only when the peak dwarfs the everyday range; lift by headroom so the
+  // everyday band sits just below the ceiling and spikes clip visibly above it
+  return cap > 0 && trueMax > margin * cap ? cap * headroom : trueMax;
 }

--- a/assets/js/utils/robustPriceMax.ts
+++ b/assets/js/utils/robustPriceMax.ts
@@ -1,45 +1,32 @@
-// Robust upper bound for price charts.
+// Upper bound for price charts.
 //
-// Dynamic tariffs (e.g. AU AEMO/Amber) occasionally spike from a few c/kWh to
-// $20/kWh. Auto-scaling the axis to that peak flattens the normal range into an
-// unreadable line. Instead we cap the axis at a high percentile so the everyday
-// range stays readable and the rare spikes clip at the top.
+// Dynamic tariffs (e.g. AU AEMO/Amber) occasionally spike from a normal range
+// into the dollars per kWh. Auto-scaling the axis to that peak flattens the
+// everyday range into an unreadable line.
 //
-// The cap is only applied when the peak genuinely dwarfs the bulk of the data
-// (margin guard), so calm/elevated days without a spike still scale to their
-// true maximum and nothing is clipped.
+// A fixed spike threshold caps the axis: prices above it clip at the ceiling
+// while everything below keeps a natural linear scale. Unlike a percentile cap
+// this never clips legitimately-high-but-not-spike peaks — only prices that
+// exceed the threshold are treated as spikes.
+//
+// The threshold is expressed in the same unit as the values passed in; callers
+// scale PRICE_SPIKE_CLIP (main currency unit per kWh) to their chart's unit.
+
+export const PRICE_SPIKE_CLIP = 3; // clip prices above 3 /kWh (e.g. AU $3/kWh)
 
 export interface RobustPriceMaxOptions {
-  percentile?: number; // axis cap percentile, default 95 (clips ~top 5% of slots)
-  margin?: number; // only clip when trueMax > margin * percentileValue, default 1.5
-  headroom?: number; // when clipping, lift the cap this much above the percentile so
-  // spikes clip *above* the everyday band (distinct), default 1.1
-}
-
-function percentileOf(sortedAsc: number[], p: number): number {
-  if (sortedAsc.length === 0) return 0;
-  const idx = Math.min(sortedAsc.length - 1, Math.max(0, Math.floor((p / 100) * sortedAsc.length)));
-  return sortedAsc[idx] as number;
+  threshold?: number; // clip above this (chart units); no clipping when unset
 }
 
 /**
- * Returns the value to use as the chart's upper bound: the percentile value when
- * a dominant spike is present, otherwise the true maximum (no clipping).
+ * Returns the chart's upper bound: the threshold when a spike exceeds it,
+ * otherwise the true maximum (so non-spike data scales to its natural range).
  */
 export function robustPriceMax(values: number[], opts: RobustPriceMaxOptions = {}): number {
-  const { percentile = 95, margin = 1.5, headroom = 1.1 } = opts;
+  const { threshold } = opts;
   const finite = values.filter((v) => Number.isFinite(v));
   if (finite.length === 0) return 0;
 
   const trueMax = Math.max(...finite);
-  const sorted = [...finite].sort((a, b) => a - b);
-  const cap = percentileOf(sorted, percentile);
-
-  // clip only when the peak dwarfs the everyday range; lift by headroom so the
-  // everyday band sits just below the ceiling and spikes clip visibly above it
-  if (cap > 0 && trueMax > margin * cap) {
-    // toPrecision strips float artefacts (e.g. 55.00000000001) from the axis max
-    return Number((cap * headroom).toPrecision(12));
-  }
-  return trueMax;
+  return threshold != null && threshold > 0 && trueMax > threshold ? threshold : trueMax;
 }


### PR DESCRIPTION
## Problem

Dynamic tariffs (AU AEMO/Amber) occasionally spike into the dollars per kWh. Auto-scaling the y-axis to that peak flattens the everyday range into an unreadable line — across the forecast, optimizer, and grid-charging charts.

(Plain **log scale**, the earlier #40 attempt, is a dead end: these tariffs also go **negative**.)

## Approach — fixed spike threshold

Shared helper `assets/js/utils/robustPriceMax.ts`:
- clips prices above **`PRICE_SPIKE_CLIP`** (default **3** in the main currency unit per kWh, i.e. $3/kWh) — spikes clip at the ceiling, everything below keeps a natural linear scale;
- when nothing exceeds the threshold, scales to the true max — so **non-spike days and legitimately-high peaks are never clipped** (a real ~$1.10/kWh AU peak stays fully visible);
- leaves the lower bound (negatives) untouched.

> An earlier iteration used a P95 percentile cap, but that clipped real high-but-not-spike peaks — replaced with the fixed threshold.

Applied consistently to all price charts (each keeps its own engine and scales the base threshold to its unit):

| Chart | Engine | Change |
|---|---|---|
| `Tariff/TariffChart.vue` (grid charging / feed-in / planner) | SVG bars | cap bar-height normalisation; spikes clip to full height with a hatched cap |
| `Forecast/PriceChart.vue` | ECharts | cap `yAxis.max`; red scatter dots flag clipped slots |
| `Optimize/PriceChart.vue` | Chart.js | cap `scales.y.max` (× display factor); red points flag clipped slots |

Spikes clip at the ceiling; the true value/range stays in the tooltip and subtitle. `PRICE_SPIKE_CLIP` is a one-line knob.

## Verification

- Unit tests (threshold clip, no-clip below threshold, no-threshold passthrough, non-finite/empty). vitest green, `vue-tsc` 0 errors, eslint/prettier clean.
- Previewed against a live AU instance: the real ~$1.10/kWh morning peak shows in full (not clipped); a seeded $20 spike clips at $3 with the everyday range readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)