### PR TITLE
fix(battery): show planner tariff in grid-charge graph

### DIFF
--- a/assets/js/components/Battery/BatteryExperimental.vue
+++ b/assets/js/components/Battery/BatteryExperimental.vue
@@ -109,7 +109,7 @@ export default defineComponent({
 		},
 		gridChargeTariff() {
 			const { forecast, smartCostType } = this.state;
-			return smartCostType === SMART_COST_TYPE.CO2 ? forecast?.co2 : forecast?.grid;
+			return smartCostType === SMART_COST_TYPE.CO2 ? forecast?.co2 : forecast?.planner;
 		},
 		smartCostLimitProps() {
 			return {


### PR DESCRIPTION
## Problem
In the experimental battery view, the **grid charging** price chart was showing the **grid** tariff, but battery grid charging is decided against the **planner** tariff. Users saw grid prices while charging actually triggers on planner prices — confusing and, when the two tariffs differ, plainly wrong.

## Root cause
`BatteryExperimental.vue` `gridChargeTariff()` bound the chart to `forecast?.grid`:

```js
return smartCostType === SMART_COST_TYPE.CO2 ? forecast?.co2 : forecast?.grid;
```

## Backend logic uses the planner tariff
The decision path consumes `TariffUsagePlanner`, never grid:
- `core/site.go` `update()` → `consumption := site.tariffRates(api.TariffUsagePlanner)` → `rate := consumption.At(now)`
- → `batteryGridChargeActive(rate)` (`core/site_battery.go`) compares that planner rate against the grid-charge limit
- `SmartCostAvailable` / `SmartCostType` are also derived from `TariffUsagePlanner`

## Fix
Use `forecast?.planner`, matching:
- the non-experimental `views/Battery.vue` (already correct)
- the loadpoint `SmartCostLimit` (`Loadpoints/SettingsModal.vue` → `:tariff="forecast?.planner"`)

```js
return smartCostType === SMART_COST_TYPE.CO2 ? forecast?.co2 : forecast?.planner;
```

CO2 branch is unchanged. One-line change.