### PR TITLE
fix(battery): show planner tariff in grid-charge graph (0.311.0 point release)

### DIFF
--- a/assets/js/components/Battery/BatteryExperimental.vue
+++ b/assets/js/components/Battery/BatteryExperimental.vue
@@ -110,7 +110,7 @@ export default defineComponent({
 		},
 		gridChargeTariff() {
 			const { forecast, smartCostType } = this.state;
-			return smartCostType === SMART_COST_TYPE.CO2 ? forecast?.co2 : forecast?.grid;
+			return smartCostType === SMART_COST_TYPE.CO2 ? forecast?.co2 : forecast?.planner;
 		},
 		smartCostLimitProps() {
 			return {


### PR DESCRIPTION
Point-release backport of the master fix (#56) onto `tag-0.311.0`.

## Problem
In the experimental battery view, the **grid charging** price chart showed the **grid** tariff, but battery grid charging is decided against the **planner** tariff — so the graph didn't match what actually triggers charging.

## Fix
`BatteryExperimental.vue` `gridChargeTariff()`: `forecast?.grid` → `forecast?.planner`, matching the backend decision (`core/site.go` → `tariffRates(api.TariffUsagePlanner)` → `batteryGridChargeActive`), the non-experimental `views/Battery.vue`, and the loadpoint `SmartCostLimit`. CO2 branch unchanged. One-line change.