### PR TITLE
feat(battery): manual optimizer p_a override in new battery dialog

### DIFF
--- a/assets/js/components/Battery/BatteryConfigCard.vue
+++ b/assets/js/components/Battery/BatteryConfigCard.vue
@@ -140,6 +140,47 @@
 					{{ $t("batterySettings.optimizerSocGoal.hint") }}
 				</small>
 			</div>
+
+			<div class="border-top pt-3 mt-3">
+				<div class="form-check form-switch mb-3">
+					<input
+						id="batteryExpManualPAEnabled"
+						:checked="optimizerManualPAEnabled"
+						class="form-check-input"
+						type="checkbox"
+						role="switch"
+						@change="changeOptimizerManualPAEnabled"
+					/>
+					<label class="form-check-label" for="batteryExpManualPAEnabled">
+						{{ $t("batterySettings.optimizerPA.enable") }}
+					</label>
+				</div>
+				<div class="row g-3 align-items-end">
+					<div class="col-sm-6">
+						<label class="form-label" for="batteryExpManualPA">
+							{{ $t("batterySettings.optimizerPA.value") }}
+						</label>
+						<div class="input-group">
+							<input
+								id="batteryExpManualPA"
+								v-model="selectedOptimizerManualPA"
+								type="number"
+								inputmode="decimal"
+								step="0.001"
+								class="form-control mx-0"
+								:disabled="!optimizerManualPAEnabled"
+								@change="changeOptimizerManualPA"
+							/>
+							<span class="input-group-text">
+								{{ pricePerKWhUnit(currency) }}
+							</span>
+						</div>
+					</div>
+				</div>
+				<small class="d-block text-muted mt-2">
+					{{ $t("batterySettings.optimizerPA.hint") }}
+				</small>
+			</div>
 		</template>
 	</Card>
 </template>
@@ -150,7 +191,7 @@ import "@h2d2/shopicons/es/regular/lightning";
 import { defineComponent, type PropType } from "vue";
 import formatter from "@/mixins/formatter";
 import api from "@/api";
-import type { Battery, BatteryOptimizerSocGoal } from "@/types/evcc";
+import { CURRENCY, type Battery, type BatteryOptimizerSocGoal } from "@/types/evcc";
 import Card from "../Helper/Card.vue";
 import InlineSocSelect from "./InlineSocSelect.vue";
 
@@ -171,6 +212,8 @@ export default defineComponent({
 			type: [Object, null] as PropType<BatteryOptimizerSocGoal | null>,
 			default: null,
 		},
+		optimizerManualPA: { type: [Number, null] as PropType<number | null>, default: null },
+		currency: { type: String as PropType<CURRENCY>, default: CURRENCY.EUR },
 		battery: { type: Object as PropType<Battery> },
 	},
 	data() {
@@ -180,6 +223,8 @@ export default defineComponent({
 			selectedBufferStartSoc: 0,
 			selectedBatteryOptimizerSocGoal: 20,
 			selectedBatteryOptimizerSocGoalTime: "21:00",
+			selectedOptimizerManualPA: "",
+			optimizerManualPAEnabled: false,
 		};
 	},
 	computed: {
@@ -253,6 +298,17 @@ export default defineComponent({
 			handler(goal: BatteryOptimizerSocGoal | null) {
 				this.selectedBatteryOptimizerSocGoal = goal?.soc ?? 20;
 				this.selectedBatteryOptimizerSocGoalTime = goal?.time || "21:00";
+			},
+			immediate: true,
+		},
+		optimizerManualPA: {
+			handler(value: number | null) {
+				this.optimizerManualPAEnabled = value !== null && value !== undefined;
+				if (value !== null && value !== undefined) {
+					this.selectedOptimizerManualPA = String(
+						value * this.pricePerKWhDisplayFactor(this.currency)
+					);
+				}
 			},
 			immediate: true,
 		},
@@ -341,6 +397,37 @@ export default defineComponent({
 				time: this.selectedBatteryOptimizerSocGoalTime,
 				tz: this.timezone(),
 			});
+		},
+		async changeOptimizerManualPAEnabled(e: Event) {
+			const enabled = (e.target as HTMLInputElement).checked;
+			this.optimizerManualPAEnabled = enabled;
+			try {
+				if (!enabled) {
+					await api.delete("optimizermanualpa");
+					return;
+				}
+				await this.saveOptimizerManualPA();
+			} catch (err) {
+				console.error(err);
+			}
+		},
+		async changeOptimizerManualPA() {
+			try {
+				await this.saveOptimizerManualPA();
+			} catch (err) {
+				console.error(err);
+			}
+		},
+		async saveOptimizerManualPA() {
+			if (!this.optimizerManualPAEnabled) {
+				return;
+			}
+			const value = Number.parseFloat(this.selectedOptimizerManualPA);
+			if (!Number.isFinite(value)) {
+				return;
+			}
+			const baseValue = value / this.pricePerKWhDisplayFactor(this.currency);
+			await api.post(`optimizermanualpa/${encodeURIComponent(baseValue)}`);
 		},
 		getBufferStartName(value: number) {
 			const key = value === 0 ? "never" : value === 100 ? "full" : "above";

--- a/assets/js/components/Battery/BatteryExperimental.vue
+++ b/assets/js/components/Battery/BatteryExperimental.vue
@@ -17,6 +17,8 @@
 			:buffer-start-soc="state.bufferStartSoc"
 			:battery-discharge-control="state.batteryDischargeControl"
 			:battery-optimizer-soc-goal="state.batteryOptimizerSocGoal"
+			:optimizer-manual-p-a="state.optimizerManualPA"
+			:currency="state.currency"
 			:battery="state.battery"
 		/>
 


### PR DESCRIPTION
## What
Re-adds the **manual optimizer `p_a` override** (`optimizerManualPA`) to the new experimental battery dialog. It was left behind on the classic `BatteryUsageSettings` tab during the 0.311.0 battery-tab redesign (out of scope at the time).

`p_a` is the optimizer's end-of-horizon energy value per Wh. When unset it's computed automatically (`site.optimizerPA` → `min(grid)·eta·0.99`); when set, this manual value (currency/kWh) is used instead.

## Changes (frontend only)
- **`BatteryConfigCard.vue`** — new `optimizerManualPA` + `currency` props; a toggle + numeric value input (with the currency/kWh unit) placed inside the `controllable` block, right after the optimizer SoC-goal section. Mirrors the existing `batteryOptimizerSocGoal` wiring (prop → watcher → API). Enabling/editing → `POST /optimizermanualpa/{value}`; disabling → `DELETE /optimizermanualpa`. Values convert via `pricePerKWhDisplayFactor`, matching the old dialog.
- **`BatteryExperimental.vue`** — passes `:optimizer-manual-p-a="state.optimizerManualPA"` and `:currency="state.currency"`.

## Not touched
Backend (`SetOptimizerManualPA`, `site.optimizerPA`, restore/publish), the `POST`/`DELETE /optimizermanualpa` routes, and the `batterySettings.optimizerPA.*` i18n keys (en + de) all already exist — this is purely reconnecting the UI.

## Verified
`vue-tsc`, `eslint`, `prettier` all clean.