### PR TITLE
feat(plan): abort plan overrun into undefined tariff (demand) window

### DIFF
--- a/core/loadpoint.go
+++ b/core/loadpoint.go
@@ -2104,7 +2104,7 @@ func (lp *Loadpoint) Update(sitePower, batteryBoostPower float64, consumption, f
 	lp.publish(keys.Mode, mode)
 
 	// update and publish plan without being short-circuited by modes etc.
-	plannerActive := lp.plannerActive()
+	plannerActive := lp.plannerActive(consumption)
 
 	// update and publish min soc not reached state
 	minSocNotReached := lp.minSocNotReached()

--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -122,8 +122,26 @@ func (lp *Loadpoint) GetPlan(targetTime time.Time, requiredDuration, preconditio
 	return lp.planner.Plan(requiredDuration, precondition, targetTime, continuous)
 }
 
-// plannerActive checks if the charging plan has a currently active slot
-func (lp *Loadpoint) plannerActive() (active bool) {
+// plannerRateGap reports whether the planner tariff is defined but has no rate
+// slot covering t - e.g. a demand window intentionally left undefined. It only
+// considers interior gaps (t within the published horizon); it returns false
+// when no dynamic rates exist (static / no tariff) or t lies beyond the last
+// published slot, so those keep the default overrun behavior.
+func plannerRateGap(rates api.Rates, t time.Time) bool {
+	if len(rates) == 0 {
+		return false
+	}
+	if t.Before(rates[0].Start) || !t.Before(rates[len(rates)-1].End) {
+		return false
+	}
+	_, err := rates.At(t)
+	return err != nil
+}
+
+// plannerActive checks if the charging plan has a currently active slot.
+// rates are the planner tariff rates, used to detect overrun into an
+// undefined-tariff (demand) window.
+func (lp *Loadpoint) plannerActive(rates api.Rates) (active bool) {
 	defer func() {
 		lp.setPlanActive(active)
 	}()
@@ -220,6 +238,12 @@ func (lp *Loadpoint) plannerActive() (active bool) {
 	} else if lp.planActive {
 		// planner was active (any slot, not necessarily previous slot) and charge goal has not yet been met
 		switch {
+		case lp.clock.Now().After(planTime) && !planTime.IsZero() && plannerRateGap(rates, lp.clock.Now()):
+			// overrun into a window with no defined planner tariff rate (e.g. a demand
+			// window intentionally left undefined) - abort instead of charging through it
+			lp.log.DEBUG.Println("plan: overrun into undefined tariff window- aborting plan")
+			lp.finishPlan()
+			return false
 		case lp.clock.Now().After(planTime) && !planTime.IsZero():
 			// if the plan did not (entirely) work, we may still be charging beyond plan end- in that case, continue charging
 			// TODO check when schedule is implemented

--- a/core/loadpoint_plan_test.go
+++ b/core/loadpoint_plan_test.go
@@ -1,0 +1,48 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/evcc-io/evcc/api"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPlannerRateGap verifies detection of an interior gap in the planner tariff
+// (a demand window intentionally left undefined) vs. covered slots, static/no
+// tariff and the region beyond the published horizon.
+func TestPlannerRateGap(t *testing.T) {
+	base := time.Date(2026, 7, 6, 0, 0, 0, 0, time.UTC)
+	at := func(h int) time.Time { return base.Add(time.Duration(h) * time.Hour) }
+
+	// rates cover 08:00-15:00 and 21:00-24:00, leaving 15:00-21:00 as a gap;
+	// includes a zero-price slot to prove a gap differs from a 0 value
+	rates := api.Rates{
+		{Start: at(8), End: at(12), Value: 0.20},
+		{Start: at(12), End: at(15), Value: 0}, // zero-price, but covered
+		{Start: at(21), End: at(24), Value: 0.10},
+	}
+
+	tc := []struct {
+		name  string
+		rates api.Rates
+		t     time.Time
+		want  bool
+	}{
+		{"interior gap (demand window)", rates, at(18), true},
+		{"covered slot", rates, at(9), false},
+		{"covered zero-price slot", rates, at(13), false},
+		{"gap edge start", rates, at(15), true},       // 15:00 not covered (slot ends at 15:00)
+		{"gap edge end", rates, at(20), true},         // still before 21:00 slot
+		{"before horizon", rates, at(7), false},       // earlier than first slot
+		{"beyond horizon tail", rates, at(24), false}, // at/after last slot end
+		{"no rates", nil, at(18), false},
+		{"empty rates", api.Rates{}, at(18), false},
+	}
+
+	for _, tc := range tc {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, plannerRateGap(tc.rates, tc.t))
+		})
+	}
+}


### PR DESCRIPTION
## Problem
My planner tariff intentionally leaves the **3–9pm demand window undefined** (no rate slots), so it's never selected for charge plans, cheap-price charging or battery grid charging.

But if a charging plan is **overrunning** — past its target time with the goal not yet met — the loadpoint keeps charging through that window. In `plannerActive()`, once `now > planTime`, this branch returns `true` unconditionally:

```go
case lp.clock.Now().After(planTime) && !planTime.IsZero():
    lp.log.DEBUG.Println("plan: continuing after target time")
    return true
```

Battery + circuit limits do cover it, but I'd rather the plan just **abort** than charge into the demand window.

## Fix
When a plan overruns **and** the current time falls in an **interior gap** of the planner tariff (rates defined either side but none covering `now`), abort the plan (`finishPlan()`) instead of continuing:

```go
case lp.clock.Now().After(planTime) && !planTime.IsZero() && plannerRateGap(rates, lp.clock.Now()):
    lp.log.DEBUG.Println("plan: overrun into undefined tariff window- aborting plan")
    lp.finishPlan()
    return false
```

Gap detection uses `api.Rates.At(t)` returning `ErrNotAvailable`, which is distinct from a zero-price slot. It's guarded so:
- **static / no dynamic tariff** → `len(rates)==0` → no change (default overrun behavior)
- **beyond the published horizon** (`now` after the last slot) → no change; only *interior* holes count as demand windows
- a **zero-price slot** is covered, not a gap

`plannerActive()` now receives the planner rates — already in scope at the call site as `consumption` (`site.tariffRates(api.TariffUsagePlanner)`).

For repeating plans `finishPlan()` is a no-op, so a daily plan simply re-triggers next occurrence rather than being deleted.

## Scope note
Applies to non-continuous (optimal) plans, which is what this tariff setup uses — the planner only schedules real rate slots, so the demand window is only ever entered via overrun. Continuous-mode plans (which synthesise slots to fill gaps) are intentionally not affected.

## Tests
`TestPlannerRateGap` covers interior gap, covered slot, covered zero-price slot, gap edges, before-horizon, beyond-horizon tail, and empty/no rates. Full `go test ./core/...` green; `go build` + `go vet` clean.