### PR TITLE
ci: harden sync workflows with least-privilege permissions

### DIFF
--- a/.github/workflows/sync-tags-pr.yml
+++ b/.github/workflows/sync-tags-pr.yml
@@ -6,6 +6,11 @@ on:
       - closed
   workflow_dispatch: # Allows manual trigger of the workflow
 
+# Least privilege: tag pushes authenticate with EVCC_PAT (set via checkout),
+# so the default GITHUB_TOKEN only needs read access.
+permissions:
+  contents: read
+
 jobs:
   finalize:
     if: github.event.pull_request.merged == true
@@ -25,13 +30,16 @@ jobs:
 
       - name: Get merged branch name
         id: get-branch
-        run: echo "BRANCH=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
+        # Pass the ref through env to avoid shell injection from branch names.
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: echo "BRANCH=$BASE_REF" >> "$GITHUB_ENV"
 
       - name: Validate branch name
         id: validate-branch
         run: |
           # Extract the tag name from the branch name
-          TAG_NAME=$(echo "${{ env.BRANCH }}" | sed 's/tag-//')
+          TAG_NAME=$(echo "$BRANCH" | sed 's/tag-//')
 
           # Check if the tag name matches the expected pattern
           if [[ ! "$TAG_NAME" =~ ^0\.[0-9]+\.[0-9]+$ ]]; then
@@ -47,7 +55,7 @@ jobs:
         if: success() && steps.validate-branch.outcome == 'success'
         run: |
           # Checkout the branch that was merged
-          git checkout "${{ env.BRANCH }}"
+          git checkout "$BRANCH"
 
           # Base version derived from the tag branch, e.g. 0.311.0
           BASE="${{ steps.validate-branch.outputs.BRANCH }}"

--- a/.github/workflows/sync-tags.yml
+++ b/.github/workflows/sync-tags.yml
@@ -6,6 +6,13 @@ on:
     - cron: "0 20 * * *"
   workflow_dispatch: # Allows manual trigger
 
+# Least privilege: branch/tag pushes authenticate with EVCC_PAT (set via
+# checkout); GITHUB_TOKEN is used only by `gh pr create`, which needs
+# pull-requests: write.
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -6,6 +6,11 @@ on:
     - cron: "0 20 * * *"
   workflow_dispatch: # Allows manual trigger of the workflow
 
+# Least privilege: pushes authenticate with EVCC_PAT (set via checkout),
+# so the default GITHUB_TOKEN only needs read access.
+permissions:
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Security hardening for the three `sync*` GitHub Actions workflows.

### 1. Least-privilege `permissions:` blocks

None of the sync workflows declared a `permissions:` block, so each ran with the repository's default (broad) `GITHUB_TOKEN`. Added minimal scopes:

| Workflow | Permissions | Rationale |
|---|---|---|
| `sync-upstream.yml` | `contents: read` | Pushes authenticate via `EVCC_PAT` (persisted by checkout), not `GITHUB_TOKEN`. |
| `sync-tags-pr.yml` | `contents: read` | Tag pushes use `EVCC_PAT`. |
| `sync-tags.yml` | `contents: read` + `pull-requests: write` | `gh pr create` uses `GITHUB_TOKEN` and needs PR write. |

### 2. Shell-injection fix in `sync-tags-pr.yml`

`github.event.pull_request.base.ref` was interpolated straight into a `run:` script. It's now passed through an `env:` var (`BASE_REF`) and the later steps reference the shell variable `$BRANCH` instead of re-interpolating `${{ env.BRANCH }}`, closing the injection vector.

## Notes
- No behavior change to the sync logic itself.
- All three files validated as well-formed YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)