### PR TITLE
fix(ui): format Optimize.vue to fix UI Porcelain CI failure

### DIFF
--- a/assets/js/views/Optimize.vue
+++ b/assets/js/views/Optimize.vue
@@ -2,20 +2,20 @@
 	<div class="container px-4 safe-area-inset">
 		<TopHeader title="Optimize Debug 🧪" />
 		<Card edge-to-edge class="box-pull-out mt-4 mb-4">
-      <OptimizeHeader
-        :updated="evopt?.updated"
-        :status="evopt?.res?.status"
-        :net-cost="netCost"
-        :horizon-hours="horizonHours"
-        :currency="currency"
-        :charging-strategies="chargingStrategies"
-        :selected-strategy="optimizerChargingStrategy"
-        :discharge-to-grid="optimizerDischargeToGrid"
-        :pending="pending"
-        @optimize="optimizeNow"
-        @change-strategy="changeChargingStrategy"
-        @change-discharge-to-grid="changeDischargeToGrid"
-      />
+			<OptimizeHeader
+				:updated="evopt?.updated"
+				:status="evopt?.res?.status"
+				:net-cost="netCost"
+				:horizon-hours="horizonHours"
+				:currency="currency"
+				:charging-strategies="chargingStrategies"
+				:selected-strategy="optimizerChargingStrategy"
+				:discharge-to-grid="optimizerDischargeToGrid"
+				:pending="pending"
+				@optimize="optimizeNow"
+				@change-strategy="changeChargingStrategy"
+				@change-discharge-to-grid="changeDischargeToGrid"
+			/>
 		</Card>
 		<div class="row">
 			<main class="col-12">


### PR DESCRIPTION
## Context

The auto-generated tag-sync PR #61 has two red checks. This addresses them.

### Issue 1 — UI Porcelain failure (fixed here)

`assets/js/views/Optimize.vue` was committed with space indentation, but the project's prettier config uses tabs (`useTabs`). During CI, `make lint-ui` runs `prettier --write` and rewrites the file, leaving the working tree dirty, so the **UI → Porcelain** step (`test -z "$(git status --porcelain)"`) fails.

Fix: reindent the file via prettier. **Whitespace-only** change — `git diff -w` is empty. `make lint-ui` now passes with a clean tree.

### Issue 2 — flaky `TestShipPairing` (already fixed in-tree, no change needed)

The failing `Test` job was `server/eebus/test` → `TestShipPairing` (`paired device not routed to consumer`). This is the flake fixed upstream by [evcc-io/evcc#31560](https://github.com/evcc-io/evcc/pull/31560), and that fix (commit `3e5183754`) is **already present** in `master`, in `tag-0.311.1`, and in their merge.

Evidence it was a flake, not a missing fix: on the same commit `8a4c942bc`, the `push` run's Test job **passed** while the `pull_request` run's Test job **failed** — same code, both with the fix. It should go green on the next run. (Upstream runs this on Depot runners; on the fork's GitHub-hosted runners the mDNS-based pairing is more timing-sensitive.)

## Result
- `make lint-ui`: clean ✓
- Once merged to `master`, PR #61 re-runs and both checks should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)