### PR TITLE
ci(perf): Playwright --workers=3

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -258,7 +258,7 @@ jobs:
         timeout-minutes: 5
 
       - name: Run tests
-        run: npx playwright test
+        run: npx playwright test --workers=3
         timeout-minutes: 20
         env:
           TZ: Europe/Berlin


### PR DESCRIPTION
Perf experiment: pin the Integration job's `npx playwright test` to **--workers=3** to measure the 'Run tests' step duration on `ubuntu-24.04`.

Compare against the sibling PRs (workers 3/4/6/8) to find the sweet spot before oversubscription. **Not for merge** — measurement only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)