### PR TITLE
ci: shard Playwright integration tests 3× with merged report

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -205,6 +205,11 @@ jobs:
     name: Integration
     runs-on: ubuntu-24.04
 
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+
     permissions:
       contents: read
       actions: write
@@ -258,23 +263,62 @@ jobs:
         timeout-minutes: 5
 
       - name: Run tests
-        run: npx playwright test
+        run: npx playwright test --shard=${{ matrix.shard }}/3 --workers=3 --reporter=blob
         timeout-minutes: 20
         env:
           TZ: Europe/Berlin
 
-      - name: Upload Playwright Report
+      - name: Upload blob report
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 14
+          name: blob-report-${{ matrix.shard }}
+          path: blob-report/
+          retention-days: 1
 
       - name: Upload Playwright Raw Test Results
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: playwright-test-results
+          name: playwright-test-results-${{ matrix.shard }}
           path: test-results/
           retention-days: 2
+
+  integration-report:
+    name: Integration Report
+    if: ${{ !cancelled() }}
+    needs: integration
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "26"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download blob reports
+        uses: actions/download-artifact@v7
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+
+      - name: Merge blobs into a single HTML report
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Upload merged HTML report
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14


### PR DESCRIPTION
## What

Splits the **Integration** job into **3 parallel shards** and merges their results into a single HTML report.

- `integration` job gains a `strategy.matrix.shard: [1, 2, 3]` (with `fail-fast: false`).
- Test step now runs `npx playwright test --shard=${{ matrix.shard }}/3 --workers=3 --reporter=blob`.
- Each shard uploads a `blob-report-<shard>` artifact.
- New dependent `integration-report` job downloads the blobs and runs `playwright merge-reports --reporter html` → uploads a single `playwright-report`.

## Why it's safe (no test-code changes)

The harness already fully isolates per worker in `tests/evcc.ts`: each spec spawns its own `./evcc` process on `TEST_WORKER_INDEX`-derived ports (`11000/12000/13000+idx`) with a per-worker temp SQLite DB. No shared server, no global setup, no cross-spec state — so `--shard` just partitions the 73 spec files across runners.

## Expected impact

From the last real run, the test step was **~11m 42s** (87% of a ~13.5min job); build+setup is only ~90s. Running ~⅓ of the tests per shard in parallel should bring wall-clock to roughly **~5.5–7 min**.

> Rebuilding inside each parallel shard is intentional: the build is only ~90s and tests dominate, so a centralized "build once then fan out" job would actually be *slower* wall-clock (it serializes the build before shards start). It only saves total compute, not time.

## Heads-up for reviewers / branch protection

- The required status check changes from **`Integration`** to **`Integration (1)` / `(2)` / `(3)`**. Branch protection rules referencing `Integration` will need updating (or add an aggregate gate job).
- `blob-report-<shard>` / `playwright-test-results-<shard>` names are suffixed because `upload-artifact` requires unique artifact names across matrix jobs.
- Retries (`playwright.config.ts` = 4 in CI) still apply per shard; a flaky shard can skew one run's timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)