### PR TITLE
ci: shard Playwright integration tests 4× with merged report

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -205,6 +205,11 @@ jobs:
     name: Integration
     runs-on: ubuntu-24.04
 
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+
     permissions:
       contents: read
       actions: write
@@ -258,23 +263,62 @@ jobs:
         timeout-minutes: 5
 
       - name: Run tests
-        run: npx playwright test
+        run: npx playwright test --shard=${{ matrix.shard }}/3 --workers=3 --reporter=blob
         timeout-minutes: 20
         env:
           TZ: Europe/Berlin
 
-      - name: Upload Playwright Report
+      - name: Upload blob report
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 14
+          name: blob-report-${{ matrix.shard }}
+          path: blob-report/
+          retention-days: 1
 
       - name: Upload Playwright Raw Test Results
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: playwright-test-results
+          name: playwright-test-results-${{ matrix.shard }}
           path: test-results/
           retention-days: 2
+
+  integration-report:
+    name: Integration Report
+    if: ${{ !cancelled() }}
+    needs: integration
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "26"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download blob reports
+        uses: actions/download-artifact@v7
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+
+      - name: Merge blobs into a single HTML report
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Upload merged HTML report
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -208,7 +208,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4]
 
     permissions:
       contents: read
@@ -263,7 +263,7 @@ jobs:
         timeout-minutes: 5
 
       - name: Run tests
-        run: npx playwright test --shard=${{ matrix.shard }}/3 --workers=3 --reporter=blob
+        run: npx playwright test --shard=${{ matrix.shard }}/4 --workers=3 --reporter=blob
         timeout-minutes: 20
         env:
           TZ: Europe/Berlin


### PR DESCRIPTION
## What

Splits the **Integration** job into **4 parallel shards** and merges their results into one HTML report.

- `integration` job gains `strategy.matrix.shard: [1, 2, 3, 4]` (with `fail-fast: false`).
- Test step: `npx playwright test --shard=${{ matrix.shard }}/4 --workers=3 --reporter=blob`.
- Each shard uploads a `blob-report-<shard>` artifact.
- New dependent `integration-report` job merges the blobs (`playwright merge-reports --reporter html`) into a single `playwright-report`.

## Measured impact

| | Before | After (4×) |
|---|---|---|
| Integration wall-clock | ~13m 30s | **~5m 30s** (slowest shard 4m54s + merge) |

Shard balance at 4-way: 4m25 / 4m54 / 3m17 / 3m06. (3-way left one shard at 6m10; 4-way evened it out. 6-way — #70 — gave little further gain since the split is duration-blind.)

## Why it's safe (no test-code changes)

`tests/evcc.ts` already isolates every worker: each spec spawns its own `./evcc` process on `TEST_WORKER_INDEX`-derived ports (`11000/12000/13000+idx`) with a per-worker temp SQLite DB. No shared server / global state, so `--shard` just partitions the 73 spec files.

## Heads-up for branch protection

- The required status check changes from **`Integration`** to **`Integration (1..4)`**. Update branch-protection required checks accordingly (or add an aggregate gate job).
- `blob-report-<shard>` / `playwright-test-results-<shard>` names are suffixed because `upload-artifact` requires unique names across matrix jobs.
- Sharding balances by test **count**, not duration; if specs grow uneven again, revisit with duration-based grouping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)