### PR TITLE
ci(perf): Playwright 6-way sharding

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -205,6 +205,11 @@ jobs:
     name: Integration
     runs-on: ubuntu-24.04
 
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+
     permissions:
       contents: read
       actions: write
@@ -258,23 +263,62 @@ jobs:
         timeout-minutes: 5
 
       - name: Run tests
-        run: npx playwright test
+        run: npx playwright test --shard=${{ matrix.shard }}/3 --workers=3 --reporter=blob
         timeout-minutes: 20
         env:
           TZ: Europe/Berlin
 
-      - name: Upload Playwright Report
+      - name: Upload blob report
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 14
+          name: blob-report-${{ matrix.shard }}
+          path: blob-report/
+          retention-days: 1
 
       - name: Upload Playwright Raw Test Results
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: playwright-test-results
+          name: playwright-test-results-${{ matrix.shard }}
           path: test-results/
           retention-days: 2
+
+  integration-report:
+    name: Integration Report
+    if: ${{ !cancelled() }}
+    needs: integration
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "26"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download blob reports
+        uses: actions/download-artifact@v7
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+
+      - name: Merge blobs into a single HTML report
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Upload merged HTML report
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -208,7 +208,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4, 5, 6]
 
     permissions:
       contents: read
@@ -263,7 +263,7 @@ jobs:
         timeout-minutes: 5
 
       - name: Run tests
-        run: npx playwright test --shard=${{ matrix.shard }}/3 --workers=3 --reporter=blob
+        run: npx playwright test --shard=${{ matrix.shard }}/6 --workers=3 --reporter=blob
         timeout-minutes: 20
         env:
           TZ: Europe/Berlin


### PR DESCRIPTION
Perf experiment: split the Integration job into **6** shards (`--shard=k/6 --workers=3`), with the merged HTML report job.

Compare the slowest `Integration (k)` job time against the 3-shard baseline (#68). Sharding is duration-blind (balances test **count**, not time), so expect diminishing returns and ~90s build re-paid per added shard. **Measurement only.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)