### PR TITLE
core: widen solar forecast scale upper bound to 1.5

### DIFF
--- a/core/site_tariffs.go
+++ b/core/site_tariffs.go
@@ -163,7 +163,7 @@ func (site *Site) solarDetails(solar api.Rates) solarDetails {
 // energy for the current day, queried from the metrics database. Used to
 // adjust forecasts when PV is consistently under-/over-producing relative
 // to the forecast. Returns 1.0 when not enough data is available to make
-// the ratio meaningful, or when the ratio falls outside [0.8, 1.2] (an
+// the ratio meaningful, or when the ratio falls outside [0.8, 1.5] (an
 // implausible correction, typically from partial-day data).
 func (site *Site) solarScale() float64 {
 	series, err := metrics.QueryEnergy(now.BeginningOfDay(), time.Now(), "day", true)
@@ -194,7 +194,7 @@ func (site *Site) solarScale() float64 {
 	site.log.DEBUG.Printf("solar forecast: produced %.3fkWh, forecasted %.3fkWh, scale %.3f", pv, fcst, scale)
 
 	// ignore implausible scale factors from partial-day data
-	if scale < 0.8 || scale > 1.2 {
+	if scale < 0.8 || scale > 1.5 {
 		return 1
 	}
 


### PR DESCRIPTION
## What

Raises the upper clamp in `Site.solarScale()` (`core/site_tariffs.go`) from **1.2 → 1.5**. Lower bound (0.8) unchanged.

## Why

`solarScale()` corrects the forecast by the day's produced/forecast energy ratio. Outside `[0.8, 1.2]` it discarded the correction (returned 1.0) to guard against implausible partial-day ratios — but 1.2 was too tight and clipped legitimate over-production days, so the correction "is a little off". Widening the ceiling to 1.5 lets stronger-than-forecast production feed through while still rejecting clearly implausible ratios.

Comment updated to match the new range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)