### PR TITLE
ci: per-shard Playwright html+blob artifacts, drop flaky merge job

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -263,10 +263,18 @@ jobs:
         timeout-minutes: 5
 
       - name: Run tests
-        run: npx playwright test --shard=${{ matrix.shard }}/4 --workers=3 --reporter=blob
+        run: npx playwright test --shard=${{ matrix.shard }}/4 --workers=3 --reporter=blob,html
         timeout-minutes: 20
         env:
           TZ: Europe/Berlin
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report-${{ matrix.shard }}
+          path: playwright-report/
+          retention-days: 14
 
       - name: Upload blob report
         uses: actions/upload-artifact@v7
@@ -274,51 +282,4 @@ jobs:
         with:
           name: blob-report-${{ matrix.shard }}
           path: blob-report/
-          retention-days: 1
-
-      - name: Upload Playwright Raw Test Results
-        uses: actions/upload-artifact@v7
-        if: failure()
-        with:
-          name: playwright-test-results-${{ matrix.shard }}
-          path: test-results/
-          retention-days: 2
-
-  integration-report:
-    name: Integration Report
-    if: ${{ !cancelled() }}
-    needs: integration
-    runs-on: ubuntu-24.04
-
-    permissions:
-      contents: read
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "26"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Download blob reports
-        uses: actions/download-artifact@v7
-        with:
-          path: all-blob-reports
-          pattern: blob-report-*
-          merge-multiple: true
-
-      - name: Merge blobs into a single HTML report
-        run: npx playwright merge-reports --reporter html ./all-blob-reports
-
-      - name: Upload merged HTML report
-        uses: actions/upload-artifact@v7
-        with:
-          name: playwright-report
-          path: playwright-report/
           retention-days: 14


### PR DESCRIPTION
## What

The `integration-report` job (merging the 4 blob reports into one HTML report via `playwright merge-reports`) fails frequently. This removes it and instead has **each shard emit its own HTML report and blob**:

- `--reporter=blob` → `--reporter=blob,html`
- per-shard uploads: `playwright-report-<shard>` (HTML) + `blob-report-<shard>` (blob)
- **8 artifacts** total (4 HTML + 4 blob); blobs can be merged offline with `playwright merge-reports` if a combined report is ever needed.

## Also

- Drops the `Upload Playwright Raw Test Results` step — traces/videos/screenshots are already bundled inside both the HTML report and the blob, so it was redundant.
- Blob retention bumped 1 → 14 days (matches the HTML reports, so offline merges stay possible).

Net: 48 lines removed, 9 added; no change to sharding/parallelism or run time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)