### PR TITLE
fix(plan): abort overrun in leading (forward-pruned) tariff gap

### DIFF
--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -123,15 +123,19 @@ func (lp *Loadpoint) GetPlan(targetTime time.Time, requiredDuration, preconditio
 }
 
 // plannerRateGap reports whether the planner tariff is defined but has no rate
-// slot covering t - e.g. a demand window intentionally left undefined. It only
-// considers interior gaps (t within the published horizon); it returns false
-// when no dynamic rates exist (static / no tariff) or t lies beyond the last
-// published slot, so those keep the default overrun behavior.
+// slot covering t - e.g. a demand window intentionally left undefined. Planner
+// rates are forward-pruned (slots before the current period are dropped), so a
+// t before the first published slot means the current period itself is
+// undefined - a leading demand-window gap - and counts as a gap. Only t beyond
+// the last published slot is excluded (the not-yet-published horizon), so
+// static/no-tariff setups and the region past the horizon keep the default
+// overrun behavior.
 func plannerRateGap(rates api.Rates, t time.Time) bool {
 	if len(rates) == 0 {
 		return false
 	}
-	if t.Before(rates[0].Start) || !t.Before(rates[len(rates)-1].End) {
+	// beyond the published horizon we have no data - keep the overrun behavior
+	if !t.Before(rates[len(rates)-1].End) {
 		return false
 	}
 	_, err := rates.At(t)

--- a/core/loadpoint_plan_test.go
+++ b/core/loadpoint_plan_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestPlannerRateGap verifies detection of an interior gap in the planner tariff
-// (a demand window intentionally left undefined) vs. covered slots, static/no
-// tariff and the region beyond the published horizon.
+// TestPlannerRateGap verifies detection of an undefined-tariff window (a demand
+// window left undefined), both interior and leading (forward-pruned rates), vs.
+// covered slots, static/no tariff and the region beyond the published horizon.
 func TestPlannerRateGap(t *testing.T) {
 	base := time.Date(2026, 7, 6, 0, 0, 0, 0, time.UTC)
 	at := func(h int) time.Time { return base.Add(time.Duration(h) * time.Hour) }
@@ -32,9 +32,11 @@ func TestPlannerRateGap(t *testing.T) {
 		{"interior gap (demand window)", rates, at(18), true},
 		{"covered slot", rates, at(9), false},
 		{"covered zero-price slot", rates, at(13), false},
-		{"gap edge start", rates, at(15), true},       // 15:00 not covered (slot ends at 15:00)
-		{"gap edge end", rates, at(20), true},         // still before 21:00 slot
-		{"before horizon", rates, at(7), false},       // earlier than first slot
+		{"gap edge start", rates, at(15), true}, // 15:00 not covered (slot ends at 15:00)
+		{"gap edge end", rates, at(20), true},   // still before 21:00 slot
+		// planner rates are forward-pruned, so a t before the first slot means the
+		// current period is undefined (a leading demand-window gap) - treat as gap
+		{"leading gap (undefined now)", rates, at(7), true},
 		{"beyond horizon tail", rates, at(24), false}, // at/after last slot end
 		{"no rates", nil, at(18), false},
 		{"empty rates", api.Rates{}, at(18), false},


### PR DESCRIPTION
## Problem

The plan-overrun abort added in db8914684 (stop charging into an undefined planner-tariff window, e.g. a 3–9pm demand window) **never fired in practice**.

## Root cause

Planner rates are **forward-pruned**: `tariff.go:118-120` drops slots older than the current period (`mergeRatesAfter(..., time.Now().Truncate(SlotDuration))`). So when `now` is inside the undefined 3–9pm window, the pruned rates array starts at the **9pm** slot.

`plannerRateGap` then hit the guard `t.Before(rates[0].Start)` — `now(16:00) < rates[0].Start(21:00)` — and returned `false`, classifying the demand window as "before the horizon". The abort case was skipped and the old `"continuing after target time"` branch charged straight through.

The original `TestPlannerRateGap` passed only because it used **un-pruned** synthetic rates (with past slots still present) — a state that never occurs at runtime.

## Fix

Drop the leading guard. With forward-pruned rates, `now` before the first published slot means the current period itself is undefined — a **leading** demand-window gap — and must count as a gap. Only the **trailing** beyond-horizon region (`!t.Before(rates[last].End)`) still preserves overrun, since that's genuinely not-yet-published data.

Test updated: the `before horizon → false` case becomes `leading gap (undefined now) → true`, matching runtime pruning.

## Verified
`go build ./core/` and `go test ./core/ -run Plan` pass in the devcontainer (incl. the new leading-gap case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)