### PR TITLE
fix(plan): abort overrun in leading tariff gap (0.311.1)

### DIFF
--- a/core/loadpoint_plan.go
+++ b/core/loadpoint_plan.go
@@ -123,15 +123,19 @@ func (lp *Loadpoint) GetPlan(targetTime time.Time, requiredDuration, preconditio
 }
 
 // plannerRateGap reports whether the planner tariff is defined but has no rate
-// slot covering t - e.g. a demand window intentionally left undefined. It only
-// considers interior gaps (t within the published horizon); it returns false
-// when no dynamic rates exist (static / no tariff) or t lies beyond the last
-// published slot, so those keep the default overrun behavior.
+// slot covering t - e.g. a demand window intentionally left undefined. Planner
+// rates are forward-pruned (slots before the current period are dropped), so a
+// t before the first published slot means the current period itself is
+// undefined - a leading demand-window gap - and counts as a gap. Only t beyond
+// the last published slot is excluded (the not-yet-published horizon), so
+// static/no-tariff setups and the region past the horizon keep the default
+// overrun behavior.
 func plannerRateGap(rates api.Rates, t time.Time) bool {
 	if len(rates) == 0 {
 		return false
 	}
-	if t.Before(rates[0].Start) || !t.Before(rates[len(rates)-1].End) {
+	// beyond the published horizon we have no data - keep the overrun behavior
+	if !t.Before(rates[len(rates)-1].End) {
 		return false
 	}
 	_, err := rates.At(t)

--- a/core/loadpoint_plan_test.go
+++ b/core/loadpoint_plan_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestPlannerRateGap verifies detection of an interior gap in the planner tariff
-// (a demand window intentionally left undefined) vs. covered slots, static/no
-// tariff and the region beyond the published horizon.
+// TestPlannerRateGap verifies detection of an undefined-tariff window (a demand
+// window left undefined), both interior and leading (forward-pruned rates), vs.
+// covered slots, static/no tariff and the region beyond the published horizon.
 func TestPlannerRateGap(t *testing.T) {
 	base := time.Date(2026, 7, 6, 0, 0, 0, 0, time.UTC)
 	at := func(h int) time.Time { return base.Add(time.Duration(h) * time.Hour) }
@@ -32,9 +32,11 @@ func TestPlannerRateGap(t *testing.T) {
 		{"interior gap (demand window)", rates, at(18), true},
 		{"covered slot", rates, at(9), false},
 		{"covered zero-price slot", rates, at(13), false},
-		{"gap edge start", rates, at(15), true},       // 15:00 not covered (slot ends at 15:00)
-		{"gap edge end", rates, at(20), true},         // still before 21:00 slot
-		{"before horizon", rates, at(7), false},       // earlier than first slot
+		{"gap edge start", rates, at(15), true}, // 15:00 not covered (slot ends at 15:00)
+		{"gap edge end", rates, at(20), true},   // still before 21:00 slot
+		// planner rates are forward-pruned, so a t before the first slot means the
+		// current period is undefined (a leading demand-window gap) - treat as gap
+		{"leading gap (undefined now)", rates, at(7), true},
 		{"beyond horizon tail", rates, at(24), false}, // at/after last slot end
 		{"no rates", nil, at(18), false},
 		{"empty rates", api.Rates{}, at(18), false},


### PR DESCRIPTION
Backport of #74 to the `tag-0.311.1` release branch.

## Problem
The plan-overrun abort (stop charging into an undefined planner-tariff window, e.g. a 3–9pm demand window) never fired in practice.

## Root cause
Planner rates are forward-pruned (`tariff.go` drops slots before the current period), so when `now` is inside the undefined window the pruned rates start at the slot *after* the window. `plannerRateGap`'s guard `t.Before(rates[0].Start)` then classified `now` as "before the horizon" and returned false, so the plan charged through via "continuing after target time".

## Fix
Drop the leading guard — with forward-pruned rates, `now` before the first slot means the current period is undefined (a leading demand-window gap) and must count as a gap. Only the trailing beyond-horizon region still preserves overrun. Test updated to match runtime pruning.

Verified: `go build ./core/` and `go test ./core/ -run Plan -count=1` pass in the devcontainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)