### PR TITLE
ci(release): parallel docker build (push-by-digest), promote to release tags only after tests pass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
       actions: write
 
   # Build and push the multi-arch image up front, in parallel with the test
-  # suite, under a neutral sha-<sha> tag - NOT the release/latest tags. The
-  # image is only promoted to the release tags once every job has succeeded
+  # suite. It is pushed by digest only (untagged) - NOT the release/latest
+  # tags - and only promoted to the release tags once every job has succeeded
   # (see the docker job), so a failing test never publishes a release image.
   docker-build:
     name: Build Docker image
@@ -27,6 +27,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - uses: actions/checkout@v7
@@ -44,15 +46,15 @@ jobs:
       - name: Setup Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
-      - name: Build and push (staging tag)
+      - name: Build and push by digest (untagged)
+        id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v6
-          push: true
           build-args: |
             RELEASE=1
-          tags: ghcr.io/jeffborg/evcc:sha-${{ github.sha }}
+          outputs: type=image,name=ghcr.io/jeffborg/evcc,push-by-digest=true,push=true
 
   # Promote the pre-built image to the release tags. This is a fast manifest
   # copy (no rebuild) and only runs once BOTH the full test suite and the
@@ -85,11 +87,40 @@ jobs:
           images: |
             ghcr.io/jeffborg/evcc
 
-      - name: Promote staging image to release tags
+      - name: Promote image to release tags
         run: |
-          # copy the already-built multi-arch manifest to every release tag
+          # copy the already-built multi-arch manifest (by digest) to every release tag
           args=$(echo "${{ steps.meta.outputs.tags }}" | sed 's/^/--tag /' | tr '\n' ' ')
-          docker buildx imagetools create $args ghcr.io/jeffborg/evcc:sha-${{ github.sha }}
+          docker buildx imagetools create $args ghcr.io/jeffborg/evcc@${{ needs.docker-build.outputs.digest }}
+
+  # Clean up the pre-built image if it never got promoted (i.e. a test failed),
+  # so failed releases don't leave an orphaned untagged image in the registry.
+  # On success the digest is tagged as a release and is left untouched.
+  cleanup:
+    name: Cleanup unpromoted image
+    needs:
+      - docker-build
+      - docker
+    if: always() && needs.docker-build.result == 'success' && needs.docker.result != 'success'
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+
+    steps:
+      - name: Delete unpromoted image digest
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DIGEST: ${{ needs.docker-build.outputs.digest }}
+        run: |
+          id=$(gh api --paginate "/users/jeffborg/packages/container/evcc/versions" \
+            --jq ".[] | select(.name == env.DIGEST) | .id")
+          if [ -n "$id" ]; then
+            gh api --method DELETE "/users/jeffborg/packages/container/evcc/versions/$id"
+            echo "deleted unpromoted image $DIGEST (version $id)"
+          else
+            echo "no untagged version found for $DIGEST- nothing to clean up"
+          fi
 
   release:
     name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,25 +16,13 @@ jobs:
       contents: read
       actions: write
 
-  release:
-    name: Create GitHub Release
-    needs:
-      - docker
+  # Build and push the multi-arch image up front, in parallel with the test
+  # suite, under a neutral sha-<sha> tag - NOT the release/latest tags. The
+  # image is only promoted to the release tags once every job has succeeded
+  # (see the docker job), so a failing test never publishes a release image.
+  docker-build:
+    name: Build Docker image
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-
-    steps:
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-
-  docker:
-    name: Publish Docker :release
-    needs:
-      - call-build-workflow
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -56,14 +44,7 @@ jobs:
       - name: Setup Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
-      - name: Meta
-        id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
-        with:
-          images: |
-            ghcr.io/jeffborg/evcc
-
-      - name: Publish
+      - name: Build and push (staging tag)
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
@@ -71,4 +52,56 @@ jobs:
           push: true
           build-args: |
             RELEASE=1
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ghcr.io/jeffborg/evcc:sha-${{ github.sha }}
+
+  # Promote the pre-built image to the release tags. This is a fast manifest
+  # copy (no rebuild) and only runs once BOTH the full test suite and the
+  # image build have succeeded.
+  docker:
+    name: Publish Docker :release
+    needs:
+      - call-build-workflow
+      - docker-build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Login
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Meta
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
+        with:
+          images: |
+            ghcr.io/jeffborg/evcc
+
+      - name: Promote staging image to release tags
+        run: |
+          # copy the already-built multi-arch manifest to every release tag
+          args=$(echo "${{ steps.meta.outputs.tags }}" | sed 's/^/--tag /' | tr '\n' ' ')
+          docker buildx imagetools create $args ghcr.io/jeffborg/evcc:sha-${{ github.sha }}
+
+  release:
+    name: Create GitHub Release
+    needs:
+      - docker
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
## What

Restructures the release workflow so the slow multi-arch Docker build (amd64 / arm64 / arm-v6) runs **in parallel** with the test suite instead of after it, and the release/`latest` tags are applied only once everything passes.

### Jobs
- **`docker-build`** — no `needs`, runs in parallel with `call-build-workflow`. Builds the multi-arch image and pushes it **by digest, untagged** (`push-by-digest=true`) — no release/`latest` tags yet. Exposes the digest as a job output.
- **`docker`** — `needs: [call-build-workflow, docker-build]`; promotes the pre-built image to the release tags with `docker buildx imagetools create ... @<digest>` (fast manifest copy, **no rebuild**).
- **`cleanup`** — runs only when the image was built but **not** promoted (a test failed); deletes the orphaned untagged digest from GHCR so failed releases don't accumulate images. `continue-on-error`, so a cleanup hiccup never fails the release.
- **`release`** — unchanged, `needs: docker`.

## Why push-by-digest instead of a `sha-<sha>` staging tag

A `sha-<sha>` tag would end up pointing at the **same manifest digest** as the release tags after promotion. GHCR deletes by version-digest, not by individual tag, so that staging tag could not be removed without deleting the release image. Pushing untagged-by-digest means: on success the digest simply gains the release tags (nothing left over); on failure it's a lone untagged digest the cleanup job removes.

## Payoff

Release wall-clock drops by ~the test-suite duration (build now overlaps it). A failing test never publishes a release/`latest` image.

## Can't fully verify here (tag-push only)
- YAML + job graph validated: `call-build-workflow` ∥ `docker-build` → `docker` → `release`, plus `cleanup` on the not-promoted path.
- Cleanup uses `GITHUB_TOKEN` with `packages: write` against the user-namespace package; if that returns 403 for user-owned packages, swap in a PAT (e.g. `EVCC_PAT`) with `delete:packages`. It's `continue-on-error`, so worst case an orphan lingers rather than breaking the release.
- **Reminder:** this only affects real releases once it's on the tag branch (`release.yml` runs from the tagged commit). Backport to `tag-0.311.1` still pending your go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)