### PR TITLE
fix(optimizer): don't drop a trigger during an in-flight run (cuts 0.312.1.2)

### DIFF
--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/evcc-io/evcc/api"
@@ -35,6 +36,7 @@ var (
 
 	mu               sync.Mutex
 	optimizerUpdated time.Time
+	optimizerPending atomic.Bool // a trigger arrived while a run held the lock; re-run afterwards
 )
 
 // optimizerChargingStrategies are the valid grid charging strategies; the first
@@ -49,13 +51,15 @@ const defaultOptimizerChargingStrategy = string(optimizer.OptimizerStrategyCharg
 
 // triggerOptimizer re-runs the optimizer immediately so a changed setting takes
 // effect without waiting for the next slot. It is a no-op when the optimizer is
-// not active or a run is already in progress; the running update reflects the
-// change on its next slot.
+// not active. When a run is already in progress the trigger is not lost: a
+// pending flag is set and optimizerUpdateAsync re-runs once the current run
+// finishes, so the change is never left waiting for the next scheduled cycle.
 func (site *Site) triggerOptimizer() {
 	if !sponsor.IsAuthorized() || !optimizerEnabled() {
 		return
 	}
 	if !mu.TryLock() {
+		optimizerPending.Store(true) // run in progress: re-run after it (see optimizerUpdateAsync)
 		return
 	}
 	optimizerUpdated = time.Time{} // bypass the slot/debounce gate
@@ -221,6 +225,13 @@ func (site *Site) optimizerUpdateAsync() {
 	if !mu.TryLock() {
 		return
 	}
+	// re-run if a trigger arrived while we held the lock (deferred LIFO, so this
+	// runs after mu.Unlock below, letting the re-run acquire the lock)
+	defer func() {
+		if optimizerPending.Swap(false) {
+			site.triggerOptimizer()
+		}
+	}()
 	defer mu.Unlock()
 
 	// slot/debounce gate; triggerOptimizer bypasses it by zeroing optimizerUpdated

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -68,6 +68,14 @@ func (site *Site) triggerOptimizer() {
 	go site.optimizerUpdateAsync()
 }
 
+// rerunIfPending re-triggers the optimizer when a trigger arrived during a run.
+// Called after optimizerUpdateAsync releases the lock so the re-run can proceed.
+func (site *Site) rerunIfPending() {
+	if optimizerPending.Swap(false) {
+		site.triggerOptimizer()
+	}
+}
+
 // optimizerResult wraps the optimizer publish payload to implement BytesMarshaler.
 // This ensures publishComplex serializes it as a single JSON message instead of
 // recursively decomposing each struct field and array element into individual MQTT
@@ -227,11 +235,7 @@ func (site *Site) optimizerUpdateAsync() {
 	}
 	// re-run if a trigger arrived while we held the lock (deferred LIFO, so this
 	// runs after mu.Unlock below, letting the re-run acquire the lock)
-	defer func() {
-		if optimizerPending.Swap(false) {
-			site.triggerOptimizer()
-		}
-	}()
+	defer site.rerunIfPending()
 	defer mu.Unlock()
 
 	// slot/debounce gate; triggerOptimizer bypasses it by zeroing optimizerUpdated

--- a/core/site_optimizer_test.go
+++ b/core/site_optimizer_test.go
@@ -5,16 +5,54 @@ import (
 	"time"
 
 	"github.com/evcc-io/evcc/api"
+	"github.com/evcc-io/evcc/core/keys"
 	"github.com/evcc-io/evcc/core/loadpoint"
 	"github.com/evcc-io/evcc/core/types"
+	"github.com/evcc-io/evcc/server/db"
+	"github.com/evcc-io/evcc/server/db/settings"
 	"github.com/evcc-io/evcc/tariff"
 	"github.com/evcc-io/evcc/util"
 	"github.com/evcc-io/evcc/util/config"
+	"github.com/evcc-io/evcc/util/sponsor"
 	optimizer "github.com/evcc-io/optimizer/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
+
+// TestOptimizerTriggerNotDroppedDuringRun verifies triggerOptimizer records a
+// pending re-run instead of silently dropping the trigger when a run is already
+// in progress, and that rerunIfPending consumes that flag afterwards.
+func TestOptimizerTriggerNotDroppedDuringRun(t *testing.T) {
+	// authorize sponsor + enable the optimizer so triggerOptimizer runs its body
+	require.NoError(t, db.NewInstance("sqlite", ":memory:"))
+	settings.SetBool(keys.Experimental, true)
+	settings.SetBool(keys.Optimizer, true)
+	sponsor.Subject = "test"
+	optimizerPending.Store(false)
+	t.Cleanup(func() {
+		sponsor.Subject = ""
+		settings.SetBool(keys.Experimental, false)
+		settings.SetBool(keys.Optimizer, false)
+		optimizerPending.Store(false)
+	})
+
+	site := &Site{log: util.NewLogger("test")}
+
+	// hold the optimizer lock to simulate an in-flight run
+	require.True(t, mu.TryLock(), "optimizer lock should be free at test start")
+	defer mu.Unlock()
+
+	// a trigger during the in-flight run must be recorded, not dropped
+	site.triggerOptimizer()
+	assert.True(t, optimizerPending.Load(), "trigger during a run must set the pending flag")
+
+	// the post-run hook consumes the flag (unauthorized keeps triggerOptimizer a
+	// no-op so no real run is launched from the test)
+	sponsor.Subject = ""
+	site.rerunIfPending()
+	assert.False(t, optimizerPending.Load(), "rerunIfPending must consume the pending flag")
+}
 
 func TestLoadpointProfile(t *testing.T) {
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
`triggerOptimizer()` returned silently when a run was already in progress (`if !mu.TryLock() { return }`), so a setting saved mid-run — e.g. a **battery SoC reserve goal** — was dropped and only took effect on the next scheduled optimizer cycle. This caused a "I saved it but the request doesn't include it" gap (observed live on 0.312.1.1: the reserve only appeared after a forced `POST /api/optimize`).

Fix: record a pending flag when the trigger can't get the lock, and have `optimizerUpdateAsync` re-run once the current run finishes (via `triggerOptimizer`, which zeroes `optimizerUpdated` to bypass the 2-minute debounce). Triggers are no longer lost; saved changes apply as soon as the in-flight run completes.

- `optimizerPending atomic.Bool`; set on contended trigger, `Swap`-checked in a deferred re-run registered before `mu.Unlock` (LIFO → runs after unlock so the re-run can acquire the lock).
- Converges (no new trigger → no re-run); extra runs are harmless on a personal optimizer.

Merging cuts **0.312.1.2**. Verified: gofmt · golangci-lint (0 issues) · `go build ./...` · `go test ./core/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
