### PR TITLE
ci(nightly): use GITHUB_TOKEN for gh pr create in preflight

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Pause if a resolution PR is already open
         id: guard
         env:
-          GH_TOKEN: ${{ secrets.EVCC_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # PR create/list needs the workflow token's pull-requests:write (EVCC_PAT can push but not open PRs)
         run: |
           open=$(gh pr list --repo "$GITHUB_REPOSITORY" --base master --state open \
             --json headRefName --jq '[.[] | select(.headRefName | startswith("resolve/upstream-"))] | length')
@@ -91,7 +91,7 @@ jobs:
       - name: Open resolution branch + PR on conflict
         if: steps.guard.outputs.blocked != 'true' && steps.merge.outputs.conflict == 'true'
         env:
-          GH_TOKEN: ${{ secrets.EVCC_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # PR create/list needs the workflow token's pull-requests:write (EVCC_PAT can push but not open PRs)
         run: |
           branch="resolve/upstream-$(date -u +%Y%m%d)"
           echo "::warning::master no longer merges cleanly into evcc-master — opening ${branch} for manual resolution and skipping the build."


### PR DESCRIPTION
The nightly preflight correctly detected an upstream merge conflict but then **failed** opening the resolution PR:

```
pull request create failed: GraphQL: Resource not accessible by personal access token (createPullRequest)
```

`EVCC_PAT` can push the `resolve/upstream-*` snapshot branch (contents) but can't open PRs. The preflight job already grants `GITHUB_TOKEN` `pull-requests: write`, so switch the `gh pr list`/`gh pr create` calls to `GITHUB_TOKEN` (matching `sync-tags.yml`). `EVCC_PAT` stays as the checkout token for the branch push.

With this, on an upstream conflict the nightly opens the resolution PR and skips the build (green run) instead of failing.

Run that surfaced it: https://github.com/jeffborg/evcc/actions/runs/30488710836/job/90700874696

🤖 Generated with [Claude Code](https://claude.com/claude-code)