### PR TITLE
Optimizer: re-run when planner/feedin tariffs change

### DIFF
--- a/core/site.go
+++ b/core/site.go
@@ -947,8 +947,21 @@ func (site *Site) updateMeters() error {
 		return err
 	}
 
-	if sponsor.IsAuthorized() && optimizerEnabled() && time.Since(optimizerUpdated) >= tariff.SlotDuration {
-		go site.optimizerUpdateAsync()
+	if sponsor.IsAuthorized() && optimizerEnabled() {
+		// mark a re-run when the planner/feedin tariffs change (e.g. a new MQTT
+		// price push); the dirty flag persists across cycles, so a change seen
+		// inside the rate-limit window still runs once the window opens and
+		// planner+feedin updates landing in separate cycles collapse into one run
+		if site.optimizerTariffsChanged() {
+			optimizerTariffDirty = true
+		}
+
+		slotDue := time.Since(optimizerUpdated) >= tariff.SlotDuration
+		tariffDue := optimizerTariffDirty && time.Since(optimizerUpdated) >= optimizerTariffInterval
+		if slotDue || tariffDue {
+			optimizerTariffDirty = false
+			go site.optimizerUpdateAsync()
+		}
 	}
 
 	return nil

--- a/core/site_optimizer.go
+++ b/core/site_optimizer.go
@@ -3,9 +3,12 @@ package core
 import (
 	"cmp"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
+	"math"
 	"net/http"
 	"os"
 	"slices"
@@ -38,7 +41,16 @@ var (
 	mu               sync.Mutex
 	optimizerUpdated time.Time
 	optimizerPending atomic.Bool // a trigger arrived while a run held the lock; re-run afterwards
+
+	optimizerTariffHash  uint64 // fingerprint of the planner+feedin rates last seen by the update loop
+	optimizerTariffDirty bool   // the tariffs changed and a re-run is due (persists across cycles until it fires)
 )
+
+// optimizerTariffInterval rate-limits tariff-change-driven optimizer runs. A new
+// planner/feedin price push (MQTT, every few minutes) re-runs the optimizer, but at
+// most once per interval so a burst of updates - or the planner and feedin tariffs
+// refreshing in separate update cycles - collapses into a single run.
+const optimizerTariffInterval = 4 * time.Minute
 
 // optimizerChargingStrategies are the valid grid charging strategies; the first
 // entry is the default and preserves the previous hard-coded behavior.
@@ -80,6 +92,29 @@ func (site *Site) rerunIfPending() {
 	if optimizerPending.Swap(false) {
 		site.triggerOptimizer()
 	}
+}
+
+// optimizerTariffsChanged reports whether the planner or feedin tariff rates
+// changed since the last call, updating the stored fingerprint. These are the
+// optimizer's price inputs (import via planner, export via feedin). A new price
+// push (e.g. over MQTT) flips the rate values; a slot boundary prunes past rates
+// - either way the fingerprint changes. Called once per site update cycle.
+func (site *Site) optimizerTariffsChanged() bool {
+	h := fnv.New64a()
+	var buf [16]byte
+	for _, u := range []api.TariffUsage{api.TariffUsagePlanner, api.TariffUsageFeedIn} {
+		for _, r := range tariff.Rates(site.GetTariff(u)) {
+			binary.LittleEndian.PutUint64(buf[0:8], uint64(r.Start.UnixNano()))
+			binary.LittleEndian.PutUint64(buf[8:16], math.Float64bits(r.Value))
+			_, _ = h.Write(buf[:])
+		}
+		_, _ = h.Write([]byte{0xff}) // separator so planner/feedin boundaries can't alias
+	}
+
+	sum := h.Sum64()
+	changed := sum != optimizerTariffHash
+	optimizerTariffHash = sum
+	return changed
 }
 
 // optimizerResult wraps the optimizer publish payload to implement BytesMarshaler.

--- a/core/site_optimizer_test.go
+++ b/core/site_optimizer_test.go
@@ -54,6 +54,40 @@ func TestOptimizerTriggerNotDroppedDuringRun(t *testing.T) {
 	assert.False(t, optimizerPending.Load(), "rerunIfPending must consume the pending flag")
 }
 
+// fakeRatesTariff is a minimal api.Tariff returning fixed rates for tests.
+type fakeRatesTariff struct{ rates api.Rates }
+
+func (f *fakeRatesTariff) Rates() (api.Rates, error) { return f.rates, nil }
+func (f *fakeRatesTariff) Type() api.TariffType      { return api.TariffTypePriceForecast }
+
+// TestOptimizerTariffsChanged verifies the planner/feedin rate fingerprint detects
+// a price change and reports no change when the rates are identical, so the
+// update loop only re-runs the optimizer when its price inputs actually move.
+func TestOptimizerTariffsChanged(t *testing.T) {
+	start := time.Now().Truncate(time.Hour)
+	rate := func(v float64) api.Rates {
+		return api.Rates{{Start: start, End: start.Add(tariff.SlotDuration), Value: v}}
+	}
+
+	planner := &fakeRatesTariff{rates: rate(0.20)}
+	feedin := &fakeRatesTariff{rates: rate(0.10)}
+	site := &Site{log: util.NewLogger("test"), tariffs: &tariff.Tariffs{Planner: planner, FeedIn: feedin}}
+
+	optimizerTariffHash = 0
+	t.Cleanup(func() { optimizerTariffHash = 0 })
+
+	site.optimizerTariffsChanged() // prime the fingerprint
+	assert.False(t, site.optimizerTariffsChanged(), "identical rates should report unchanged")
+
+	planner.rates = rate(0.21)
+	assert.True(t, site.optimizerTariffsChanged(), "changed planner rate should report changed")
+	assert.False(t, site.optimizerTariffsChanged(), "re-reading the changed planner rate should report unchanged")
+
+	feedin.rates = rate(0.11)
+	assert.True(t, site.optimizerTariffsChanged(), "changed feedin rate should report changed")
+	assert.False(t, site.optimizerTariffsChanged(), "re-reading the changed feedin rate should report unchanged")
+}
+
 func TestLoadpointProfile(t *testing.T) {
 	ctrl := gomock.NewController(t)
 


### PR DESCRIPTION
## Problem
The optimizer only re-ran **once per 15-minute slot**. A fresh price pushed over MQTT — e.g. every ~5 min for an Amber `type: custom` tariff — wasn't picked up until the next slot boundary, so the optimizer planned against a stale price for up to 15 minutes.

## Change
Each site update cycle fingerprints the optimizer's **price inputs** — the **planner** (import) and **feedin** (export) rates (fnv64a over each slot's start + value). These are exactly what the optimizer request reads (`site_optimizer.go` `planner`/`feedIn`); the `grid` tariff is not an optimizer input. When the fingerprint moves, the optimizer re-runs:

- **Rate-limited** to once per `optimizerTariffInterval` (**4 min**) — a burst of updates, or planner and feedin refreshing in separate cycles, collapses into a single run.
- A **dirty flag persists** a change seen inside the rate-limit window so it still fires once the window opens.
- The existing **15-minute slot run stays** as a backstop for static tariffs.

Reuses the existing `optimizerUpdateAsync` single-flight + 2-min async gate. Only runs when `sponsor.IsAuthorized() && optimizerEnabled()`. The fingerprint read (`GetTariff` → `RLock`) happens in `updateMeters`, before the update loop takes the site lock — no reentrancy.

## Tests
`TestOptimizerTariffsChanged` — fingerprint detects planner and feedin price changes, reports unchanged for identical rates. Validated: `go build ./core/...`, `gofmt` clean, `go test ./core/` ✓, `golangci-lint run ./core/...` 0 issues.

Note: raises optimizer call frequency (~every 5 min vs 15) — intended for the personal optimizer; easy to gate behind a config flag later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)